### PR TITLE
[Feature/39] 보틀 거절하기 API를 구현한다

### DIFF
--- a/src/main/kotlin/com/nexters/bottles/bottle/controller/BottleController.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/controller/BottleController.kt
@@ -29,4 +29,9 @@ class BottleController(
     fun acceptBottle(@PathVariable bottleId: Long) {
         bottleFacade.acceptBottle(bottleId)
     }
+
+    @PostMapping("{bottleId}/refuse")
+    fun refuseBottle(@PathVariable bottleId: Long) {
+        bottleFacade.refuseBottle(bottleId)
+    }
 }

--- a/src/main/kotlin/com/nexters/bottles/bottle/domain/Bottle.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/domain/Bottle.kt
@@ -41,6 +41,10 @@ class Bottle(
     var pingPongStatus: PingPongStatus = PingPongStatus.NONE,
 ) : BaseEntity() {
 
+    fun accept() {
+        this.pingPongStatus = PingPongStatus.ACTIVE
+    }
+
     fun refuse(refusedBy: User) {
         this.stoppedUser = refusedBy
         this.pingPongStatus = PingPongStatus.STOPPED

--- a/src/main/kotlin/com/nexters/bottles/bottle/domain/Bottle.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/domain/Bottle.kt
@@ -6,6 +6,8 @@ import com.nexters.bottles.user.domain.User
 import java.time.LocalDateTime
 import javax.persistence.Column
 import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
 import javax.persistence.FetchType
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
@@ -35,6 +37,12 @@ class Bottle(
     var stoppedUser: User? = null,
 
     @Column
-    val pingPongStatus: PingPongStatus = PingPongStatus.NONE,
+    @Enumerated(value = EnumType.STRING)
+    var pingPongStatus: PingPongStatus = PingPongStatus.NONE,
 ) : BaseEntity() {
+
+    fun refuse(refusedBy: User) {
+        this.stoppedUser = refusedBy
+        this.pingPongStatus = PingPongStatus.STOPPED
+    }
 }

--- a/src/main/kotlin/com/nexters/bottles/bottle/facade/BottleFacade.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/facade/BottleFacade.kt
@@ -43,4 +43,8 @@ class BottleFacade(
     fun acceptBottle(bottleId: Long) {
         bottleService.acceptBottle(bottleId)
     }
+
+    fun refuseBottle(bottleId: Long) {
+        bottleService.refuseBottle(bottleId)
+    }
 }

--- a/src/main/kotlin/com/nexters/bottles/bottle/repository/BottleRepository.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/repository/BottleRepository.kt
@@ -1,6 +1,7 @@
 package com.nexters.bottles.bottle.repository
 
 import com.nexters.bottles.bottle.domain.Bottle
+import com.nexters.bottles.bottle.domain.enum.PingPongStatus
 import com.nexters.bottles.user.domain.User
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
@@ -12,20 +13,22 @@ interface BottleRepository : JpaRepository<Bottle, Long> {
     @Query(
         value = "SELECT b FROM Bottle b " +
                 "JOIN FETCH b.sourceUser " +
-                "WHERE b.targetUser = :targetUser AND b.expiredAt > :currentDateTime"
+                "WHERE b.targetUser = :targetUser AND b.pingPongStatus = :pingPongStatus AND b.expiredAt > :currentDateTime"
     )
-    fun findByTargetUserAndNotExpired(
+    fun findByTargetUserAndStatusAndNotExpired(
         @Param("targetUser") targetUser: User,
+        @Param("pingPongStatus") pingPongStatus: PingPongStatus,
         @Param("currentDateTime") currentDateTime: LocalDateTime
     ): List<Bottle>
 
     @Query(
         value = "SELECT b FROM Bottle b " +
                 "JOIN FETCH b.sourceUser " +
-                "WHERE b.id = :bottleId AND b.expiredAt > :currentDateTime"
+                "WHERE b.id = :bottleId AND b.pingPongStatus = :pingPongStatus AND b.expiredAt > :currentDateTime"
     )
-    fun findByIdAndNotExpired(
+    fun findByIdAndStatusAndNotExpired(
         @Param("bottleId") bottleId: Long,
+        @Param("pingPongStatus") pingPongStatus: PingPongStatus,
         @Param("currentDateTime") currentDateTime: LocalDateTime
     ): Bottle?
 }

--- a/src/main/kotlin/com/nexters/bottles/bottle/repository/BottleRepository.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/repository/BottleRepository.kt
@@ -13,7 +13,7 @@ interface BottleRepository : JpaRepository<Bottle, Long> {
     @Query(
         value = "SELECT b FROM Bottle b " +
                 "JOIN FETCH b.sourceUser " +
-                "WHERE b.targetUser = :targetUser AND b.pingPongStatus = :pingPongStatus AND b.expiredAt > :currentDateTime"
+                "WHERE b.targetUser = :targetUser AND b.expiredAt > :currentDateTime AND b.pingPongStatus = :pingPongStatus"
     )
     fun findByTargetUserAndStatusAndNotExpired(
         @Param("targetUser") targetUser: User,
@@ -24,7 +24,7 @@ interface BottleRepository : JpaRepository<Bottle, Long> {
     @Query(
         value = "SELECT b FROM Bottle b " +
                 "JOIN FETCH b.sourceUser " +
-                "WHERE b.id = :bottleId AND b.pingPongStatus = :pingPongStatus AND b.expiredAt > :currentDateTime"
+                "WHERE b.id = :bottleId AND b.expiredAt > :currentDateTime AND b.pingPongStatus = :pingPongStatus"
     )
     fun findByIdAndStatusAndNotExpired(
         @Param("bottleId") bottleId: Long,

--- a/src/main/kotlin/com/nexters/bottles/bottle/service/BottleService.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/service/BottleService.kt
@@ -3,6 +3,7 @@ package com.nexters.bottles.bottle.service
 import com.nexters.bottles.bottle.domain.Bottle
 import com.nexters.bottles.bottle.domain.Letter
 import com.nexters.bottles.bottle.domain.LetterQuestionAndAnswer
+import com.nexters.bottles.bottle.domain.enum.PingPongStatus
 import com.nexters.bottles.bottle.repository.BottleRepository
 import com.nexters.bottles.bottle.repository.LetterRepository
 import com.nexters.bottles.bottle.repository.QuestionRepository
@@ -26,18 +27,18 @@ class BottleService(
         // TODO User 회원 가입 기능 구현후 수정
         val user = userRepository.findByIdOrNull(1L) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
 
-        return bottleRepository.findByTargetUserAndNotExpired(user, LocalDateTime.now())
+        return bottleRepository.findByTargetUserAndStatusAndNotExpired(user, PingPongStatus.NONE, LocalDateTime.now())
     }
 
     @Transactional(readOnly = true)
     fun getBottle(bottleId: Long): Bottle {
-        return bottleRepository.findByIdAndNotExpired(bottleId, LocalDateTime.now())
+        return bottleRepository.findByIdAndStatusAndNotExpired(bottleId, PingPongStatus.NONE, LocalDateTime.now())
             ?: throw IllegalArgumentException("이미 떠내려간 보틀이에요")
     }
 
     @Transactional
     fun acceptBottle(bottleId: Long) {
-        val bottle = bottleRepository.findByIdAndNotExpired(bottleId, LocalDateTime.now())
+        val bottle = bottleRepository.findByIdAndStatusAndNotExpired(bottleId, PingPongStatus.NONE, LocalDateTime.now())
             ?: throw IllegalArgumentException("이미 떠내려간 보틀이에요")
 
         // TODO User 회원 가입 기능 구현후 수정
@@ -70,7 +71,7 @@ class BottleService(
 
     @Transactional
     fun refuseBottle(bottleId: Long) {
-        val bottle = bottleRepository.findByIdAndNotExpired(bottleId, LocalDateTime.now())
+        val bottle = bottleRepository.findByIdAndStatusAndNotExpired(bottleId, PingPongStatus.NONE, LocalDateTime.now())
             ?: throw IllegalArgumentException("이미 떠내려간 보틀이에요")
 
         // TODO User 회원 가입 기능 구현후 수정

--- a/src/main/kotlin/com/nexters/bottles/bottle/service/BottleService.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/service/BottleService.kt
@@ -45,6 +45,8 @@ class BottleService(
         val sourceUser = userRepository.findByIdOrNull(bottle.sourceUser.id)
             ?: throw IllegalArgumentException("탈퇴한 회원이에요")
 
+        bottle.accept()
+
         val letters = findRandomQuestions()
         saveLetter(bottle, targetUser, letters)
         saveLetter(bottle, sourceUser, letters)

--- a/src/main/kotlin/com/nexters/bottles/bottle/service/BottleService.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/service/BottleService.kt
@@ -65,4 +65,16 @@ class BottleService(
         val letter = Letter(bottle = bottle, user = user, letters = letters)
         letterRepository.save(letter)
     }
+
+    @Transactional
+    fun refuseBottle(bottleId: Long) {
+        val bottle = bottleRepository.findByIdAndNotExpired(bottleId, LocalDateTime.now())
+            ?: throw IllegalArgumentException("이미 떠내려간 보틀이에요")
+
+        // TODO User 회원 가입 기능 구현후 수정
+        val targetUser = userRepository.findByIdOrNull(1L) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
+        userRepository.findByIdOrNull(bottle.sourceUser.id) ?: throw IllegalArgumentException("탈퇴한 회원이에요")
+
+        bottle.refuse(targetUser)
+    }
 }


### PR DESCRIPTION
## 💡 이슈 번호
close: #39 

## ✨ 작업 내용
보틀을 거절하는 API를 구현했습니다.

## 🚀 전달 사항
- 보틀 수락하기 API에서 보틀의 PingPongStatus를 ACTIVE로 변경하도록 수정했습니다.
- 보틀 목록 조회 API에서 보틀의 PingPongStatus가 NONE인 보틀만 조회하도록 수정했습니다.