### PR TITLE
[Fix/57] 보틀 보관함 조회 시 중단된 보틀도 함께 조회하도록 수정한다

### DIFF
--- a/src/main/kotlin/com/nexters/bottles/bottle/repository/BottleRepository.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/repository/BottleRepository.kt
@@ -15,7 +15,7 @@ interface BottleRepository : JpaRepository<Bottle, Long> {
                 "JOIN FETCH b.sourceUser " +
                 "WHERE b.targetUser = :targetUser AND b.expiredAt > :currentDateTime AND b.pingPongStatus = :pingPongStatus"
     )
-    fun findByTargetUserAndStatusAndNotExpired(
+    fun findAllByTargetUserAndStatusAndNotExpired(
         @Param("targetUser") targetUser: User,
         @Param("pingPongStatus") pingPongStatus: PingPongStatus,
         @Param("currentDateTime") currentDateTime: LocalDateTime
@@ -37,7 +37,7 @@ interface BottleRepository : JpaRepository<Bottle, Long> {
                 "WHERE (b.targetUser = :user OR b.sourceUser = :user) " +
                 "AND b.pingPongStatus IN :pingPongStatus"
     )
-    fun findByUserAndStatus(
+    fun findAllByUserAndStatus(
         @Param("user") user: User,
         @Param("pingPongStatus") pingPongStatus: Set<PingPongStatus>
     ): List<Bottle>

--- a/src/main/kotlin/com/nexters/bottles/bottle/service/BottleService.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/service/BottleService.kt
@@ -36,12 +36,6 @@ class BottleService(
             ?: throw IllegalArgumentException("이미 떠내려간 보틀이에요")
     }
 
-    @Transactional(readOnly = true)
-    fun getPingPongBottle(bottleId: Long, statusSet: Set<PingPongStatus>): Bottle {
-        return bottleRepository.findByIdAndStatus(bottleId, statusSet)
-            ?: throw IllegalArgumentException("이미 떠내려간 보틀이에요")
-    }
-
     @Transactional
     fun acceptBottle(bottleId: Long) {
         val bottle =
@@ -94,12 +88,17 @@ class BottleService(
         // TODO User 회원 가입 기능 구현후 수정
         val user = userRepository.findByIdOrNull(1L) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
 
-        return bottleRepository.findByUserAndStatus(user, setOf(PingPongStatus.ACTIVE, PingPongStatus.MATCHED))
+        return bottleRepository.findByUserAndStatus(
+            user,
+            setOf(PingPongStatus.ACTIVE, PingPongStatus.MATCHED, PingPongStatus.STOPPED)
+        )
     }
 
     @Transactional(readOnly = true)
     fun getPingPongBottle(bottleId: Long): Bottle {
-        return bottleRepository.findByIdAndStatus(bottleId, setOf(PingPongStatus.ACTIVE, PingPongStatus.MATCHED))
-            ?: throw IllegalArgumentException("고객센터에 문의해주세요")
+        return bottleRepository.findByIdAndStatus(
+            bottleId,
+            setOf(PingPongStatus.ACTIVE, PingPongStatus.MATCHED, PingPongStatus.STOPPED)
+        ) ?: throw IllegalArgumentException("고객센터에 문의해주세요")
     }
 }

--- a/src/main/kotlin/com/nexters/bottles/bottle/service/BottleService.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/service/BottleService.kt
@@ -27,7 +27,11 @@ class BottleService(
         // TODO User 회원 가입 기능 구현후 수정
         val user = userRepository.findByIdOrNull(1L) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
 
-        return bottleRepository.findByTargetUserAndStatusAndNotExpired(user, PingPongStatus.NONE, LocalDateTime.now())
+        return bottleRepository.findAllByTargetUserAndStatusAndNotExpired(
+            user,
+            PingPongStatus.NONE,
+            LocalDateTime.now()
+        )
     }
 
     @Transactional(readOnly = true)
@@ -88,7 +92,7 @@ class BottleService(
         // TODO User 회원 가입 기능 구현후 수정
         val user = userRepository.findByIdOrNull(1L) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
 
-        return bottleRepository.findByUserAndStatus(
+        return bottleRepository.findAllByUserAndStatus(
             user,
             setOf(PingPongStatus.ACTIVE, PingPongStatus.MATCHED, PingPongStatus.STOPPED)
         )


### PR DESCRIPTION
## 💡 이슈 번호
close: #57

## ✨ 작업 내용
보틀 보관함 조회 시 중단된 보틀도 함께 조회하도록 수정했습니다.

## 🚀 전달 사항
