### PR TITLE
[Feature/68] 인증/인가 기능을 구현한다

### DIFF
--- a/src/main/kotlin/com/nexters/bottles/auth/component/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/nexters/bottles/auth/component/JwtTokenProvider.kt
@@ -7,10 +7,11 @@ import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
+import java.time.Duration
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.util.*
-import java.time.Duration
+import javax.servlet.http.HttpServletRequest
 
 @Component
 class JwtTokenProvider(
@@ -63,6 +64,13 @@ class JwtTokenProvider(
         refreshTokenRepository.save(refreshToken)
 
         return token
+    }
+
+    fun resolveToken(request: HttpServletRequest): String? {
+        val bearerToken = request.getHeader("Authorization")
+        return if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            bearerToken.substring(7)
+        } else null
     }
 
     fun getUserIdFromToken(token: String, isAccessToken: Boolean): Long? {

--- a/src/main/kotlin/com/nexters/bottles/bottle/controller/BottleController.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/controller/BottleController.kt
@@ -1,7 +1,14 @@
 package com.nexters.bottles.bottle.controller
 
 import com.nexters.bottles.bottle.facade.BottleFacade
-import com.nexters.bottles.bottle.facade.dto.*
+import com.nexters.bottles.bottle.facade.dto.BottleDetailResponseDto
+import com.nexters.bottles.bottle.facade.dto.BottleListResponseDto
+import com.nexters.bottles.bottle.facade.dto.BottleMatchRequest
+import com.nexters.bottles.bottle.facade.dto.BottlePingpongResponseDto
+import com.nexters.bottles.bottle.facade.dto.PingPongListResponseDto
+import com.nexters.bottles.bottle.facade.dto.RegisterLetterRequestDto
+import com.nexters.bottles.global.interceptor.AuthRequired
+import com.nexters.bottles.global.resolver.AuthUserId
 import io.swagger.annotations.ApiOperation
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -20,67 +27,86 @@ class BottleController(
 
     @ApiOperation("홈 - 받은 보틀 목록 조회하기")
     @GetMapping
-    fun getBottlesList(): BottleListResponseDto {
-        return bottleFacade.getNewBottles()
+    @AuthRequired
+    fun getBottlesList(@AuthUserId userId: Long): BottleListResponseDto {
+        return bottleFacade.getNewBottles(userId)
     }
 
     @ApiOperation("홈 - 보틀 상세 정보 조회하기")
     @GetMapping("/{bottleId}")
+    @AuthRequired
     fun getBottleDetail(@PathVariable bottleId: Long): BottleDetailResponseDto {
         return bottleFacade.getBottle(bottleId)
     }
 
     @ApiOperation("홈 - 보틀에 내 소개 보내기(수락하기)")
     @PostMapping("/{bottleId}/accept")
-    fun acceptBottle(@PathVariable bottleId: Long) {
-        bottleFacade.acceptBottle(bottleId)
+    @AuthRequired
+    fun acceptBottle(@AuthUserId userId: Long, @PathVariable bottleId: Long) {
+        bottleFacade.acceptBottle(userId, bottleId)
     }
 
     @ApiOperation("홈 - 보틀 떠내려 보내기(거절하기)")
     @PostMapping("/{bottleId}/refuse")
-    fun refuseBottle(@PathVariable bottleId: Long) {
-        bottleFacade.refuseBottle(bottleId)
+    @AuthRequired
+    fun refuseBottle(@AuthUserId userId: Long, @PathVariable bottleId: Long) {
+        bottleFacade.refuseBottle(userId, bottleId)
     }
 
     @ApiOperation("보틀 보관함 - 보틀 보관함 조회하기")
     @GetMapping("/ping-pong")
-    fun getPingPongList(): PingPongListResponseDto {
-        return bottleFacade.getPingPongBottles()
+    @AuthRequired
+    fun getPingPongList(@AuthUserId userId: Long): PingPongListResponseDto {
+        return bottleFacade.getPingPongBottles(userId)
     }
 
     @ApiOperation("보틀 보관함 - 편지 답변 등록하기")
     @PostMapping("/ping-pong/{bottleId}/letters")
-    fun registerLetter(@PathVariable bottleId: Long, @RequestBody registerLetterRequestDto: RegisterLetterRequestDto) {
-        bottleFacade.registerLetter(bottleId, registerLetterRequestDto)
+    @AuthRequired
+    fun registerLetter(
+        @AuthUserId userId: Long,
+        @PathVariable bottleId: Long,
+        @RequestBody registerLetterRequestDto: RegisterLetterRequestDto
+    ) {
+        bottleFacade.registerLetter(userId, bottleId, registerLetterRequestDto)
     }
 
     @ApiOperation("보틀 보관함 - 보틀 읽음 표시하기")
     @PostMapping("/ping-pong/{bottleId}/read")
-    fun readPingPongBottle(@PathVariable bottleId: Long) {
-        bottleFacade.readPingPongBottle(bottleId)
+    @AuthRequired
+    fun readPingPongBottle(@AuthUserId userId: Long, @PathVariable bottleId: Long) {
+        bottleFacade.readPingPongBottle(userId, bottleId)
     }
 
     @ApiOperation("보틀 보관함 - 대화 중단하기")
     @PostMapping("/ping-pong/{bottleId}/stop")
-    fun stopBottle(@PathVariable bottleId: Long) {
-        bottleFacade.stopBottle(bottleId)
+    @AuthRequired
+    fun stopBottle(@AuthUserId userId: Long, @PathVariable bottleId: Long) {
+        bottleFacade.stopBottle(userId, bottleId)
     }
 
     @ApiOperation("보틀의 핑퐁 조회하기")
     @GetMapping("/ping-pong/{bottleId}")
-    fun getBottlePingPong(@PathVariable bottleId: Long): BottlePingpongResponseDto {
-        return bottleFacade.getBottlePingPong(bottleId)
+    @AuthRequired
+    fun getBottlePingPong(@AuthUserId userId: Long, @PathVariable bottleId: Long): BottlePingpongResponseDto {
+        return bottleFacade.getBottlePingPong(userId, bottleId)
     }
 
     @ApiOperation("보틀 보관함 - 사진 전송하기")
     @PostMapping("/ping-pong/{bottleId}/images")
-    fun uploadImage(@PathVariable bottleId: Long, @RequestPart file: MultipartFile) {
-        bottleFacade.uploadImage(bottleId, file)
+    @AuthRequired
+    fun uploadImage(@AuthUserId userId: Long, @PathVariable bottleId: Long, @RequestPart file: MultipartFile) {
+        bottleFacade.uploadImage(userId, bottleId, file)
     }
 
     @ApiOperation("최종 선택하기")
     @PostMapping("/ping-pong/{bottleId}/match")
-    fun selectMatch(@PathVariable bottleId: Long, @RequestBody bottleMatchRequest: BottleMatchRequest) {
-        bottleFacade.selectMatch(bottleId, bottleMatchRequest.willMatch)
+    @AuthRequired
+    fun selectMatch(
+        @AuthUserId userId: Long,
+        @PathVariable bottleId: Long,
+        @RequestBody bottleMatchRequest: BottleMatchRequest
+    ) {
+        bottleFacade.selectMatch(userId, bottleId, bottleMatchRequest.willMatch)
     }
 }

--- a/src/main/kotlin/com/nexters/bottles/bottle/facade/BottleFacade.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/facade/BottleFacade.kt
@@ -39,8 +39,8 @@ class BottleFacade(
             bottles.map {
                 BottleDto(
                     id = it.id,
-                    userName = "it.sourceUser.name",
-                    age = 20, // TODO User에 age 추가된 후 수정
+                    userName = it.sourceUser.name,
+                    age = it.sourceUser.getKoreanAge(),
                     mbti = it.sourceUser.userProfile?.profileSelect?.mbti,
                     keyword = it.sourceUser.userProfile?.profileSelect?.keyword,
                     expiredAt = it.expiredAt
@@ -54,8 +54,8 @@ class BottleFacade(
 
         return BottleDetailResponseDto(
             id = bottle.id,
-            userName = "bottle.sourceUser.name", // TODO User 변경된 후 수정
-            age = 20,
+            userName = bottle.sourceUser.name,
+            age = bottle.sourceUser.getKoreanAge(),
             introduction = bottle.sourceUser.userProfile?.introduction,
             profileSelect = bottle.sourceUser.userProfile?.profileSelect
         )
@@ -88,8 +88,8 @@ class BottleFacade(
         return PingPongBottleDto(
             id = bottle.id,
             isRead = otherUserLetter.isReadByOtherUser,
-            userName = "otherUser.name", // TODO User 변경된 후 수정
-            age = 20,
+            userName = otherUser.name,
+            age = otherUser.getKoreanAge(),
             mbti = otherUser.userProfile?.profileSelect?.mbti,
             keyword = otherUser.userProfile?.profileSelect?.keyword
         )

--- a/src/main/kotlin/com/nexters/bottles/bottle/facade/BottleFacade.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/facade/BottleFacade.kt
@@ -18,9 +18,9 @@ import com.nexters.bottles.bottle.service.BottleService
 import com.nexters.bottles.bottle.service.FileService
 import com.nexters.bottles.bottle.service.LetterService
 import com.nexters.bottles.user.domain.User
+import com.nexters.bottles.user.service.UserService
 import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -28,11 +28,12 @@ import java.time.format.DateTimeFormatter
 class BottleFacade(
     private val bottleService: BottleService,
     private val letterService: LetterService,
+    private val userService: UserService,
     private val fileService: FileService,
 ) {
 
-    fun getNewBottles(): BottleListResponseDto {
-        val bottles = bottleService.getNewBottles()
+    fun getNewBottles(userId: Long): BottleListResponseDto {
+        val bottles = bottleService.getNewBottles(userId)
 
         return BottleListResponseDto(
             bottles.map {
@@ -60,17 +61,17 @@ class BottleFacade(
         )
     }
 
-    fun acceptBottle(bottleId: Long) {
-        bottleService.acceptBottle(bottleId)
+    fun acceptBottle(userId: Long, bottleId: Long) {
+        bottleService.acceptBottle(userId, bottleId)
     }
 
-    fun refuseBottle(bottleId: Long) {
-        bottleService.refuseBottle(bottleId)
+    fun refuseBottle(userId: Long, bottleId: Long) {
+        bottleService.refuseBottle(userId, bottleId)
     }
 
-    fun getPingPongBottles(): PingPongListResponseDto {
-        val pingPongBottles = bottleService.getPingPongBottles()
-        val user = User(1L, LocalDate.of(2000, 1, 1), "보틀즈") // TODO 회원 기능 구현 후 수정
+    fun getPingPongBottles(userId: Long): PingPongListResponseDto {
+        val pingPongBottles = bottleService.getPingPongBottles(userId)
+        val user = userService.findById(userId)
 
         val groupByStatus = pingPongBottles.groupBy { it.pingPongStatus }
         val activeBottles =
@@ -94,9 +95,9 @@ class BottleFacade(
         )
     }
 
-    fun registerLetter(bottleId: Long, registerLetterRequestDto: RegisterLetterRequestDto) {
+    fun registerLetter(userId: Long, bottleId: Long, registerLetterRequestDto: RegisterLetterRequestDto) {
         val pingPongBottle = bottleService.getPingPongBottle(bottleId)
-        val user = User(1L, LocalDate.of(2000, 1, 1), "보틀즈") // TODO 회원 기능 구현 후 수정
+        val user = userService.findById(userId)
 
         letterService.registerLetter(
             pingPongBottle,
@@ -106,22 +107,22 @@ class BottleFacade(
         )
     }
 
-    fun readPingPongBottle(bottleId: Long) {
+    fun readPingPongBottle(userId: Long, bottleId: Long) {
         val pingPongBottle = bottleService.getPingPongBottle(bottleId)
-        val me = User(1L, LocalDate.of(2000, 1, 1), "보틀즈") // TODO 회원 기능 구현 후 수정
+        val me = userService.findById(userId)
         val otherUser = pingPongBottle.findOtherUser(me)
         letterService.readOtherUserLetter(pingPongBottle, otherUser)
     }
 
-    fun stopBottle(bottleId: Long) {
+    fun stopBottle(userId: Long, bottleId: Long) {
         val pingPongBottle = bottleService.getPingPongBottle(bottleId)
-        val me = User(1L, LocalDate.of(2000, 1, 1), "보틀즈") // TODO 회원 기능 구현 후 수정
+        val me = userService.findById(userId)
 
         pingPongBottle.stop(me)
     }
 
-    fun getBottlePingPong(bottleId: Long): BottlePingpongResponseDto {
-        val me = User(1L, LocalDate.of(2000, 1, 1), "보틀즈") // TODO: 회원 기능 갖추고 수정
+    fun getBottlePingPong(userId: Long, bottleId: Long): BottlePingpongResponseDto {
+        val me = userService.findById(userId)
         val bottle = bottleService.getPingPongBottle(bottleId)
         val otherUser = bottle.findOtherUser(me)
         val myLetter = letterService.findLetter(bottle, me)
@@ -181,9 +182,9 @@ class BottleFacade(
         )
     }
 
-    fun uploadImage(bottleId: Long, file: MultipartFile) {
+    fun uploadImage(userId: Long, bottleId: Long, file: MultipartFile) {
         val pingPongBottle = bottleService.getPingPongBottle(bottleId)
-        val me = User(1L, LocalDate.of(2000, 1, 1), "보틀즈") // TODO 회원 기능 구현 후 수정
+        val me = userService.findById(userId)
         val path = makePathWithUserId(file, me.id)
         val imageUrl = fileService.upload(file, path)
         letterService.uploadImageURl(pingPongBottle, me, imageUrl.toString())
@@ -195,8 +196,8 @@ class BottleFacade(
     ) = file.originalFilename + FILE_NAME_DELIMITER +
             LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss")) + FILE_NAME_DELIMITER + userId
 
-    fun selectMatch(bottleId: Long, willMatch: Boolean) {
-        val user = User(1L, LocalDate.of(2000, 1, 1), "보틀즈") // TODO 회원 기능 구현 후 수정
+    fun selectMatch(userId: Long, bottleId: Long, willMatch: Boolean) {
+        val user = userService.findById(userId)
 
         val previousStatus = bottleService.getPingPongBottle(bottleId).pingPongStatus
         val pingPongBottle = bottleService.selectMatch(

--- a/src/main/kotlin/com/nexters/bottles/bottle/service/BottleService.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/service/BottleService.kt
@@ -23,9 +23,8 @@ class BottleService(
 ) {
 
     @Transactional(readOnly = true)
-    fun getNewBottles(): List<Bottle> {
-        // TODO User 회원 가입 기능 구현후 수정
-        val user = userRepository.findByIdOrNull(1L) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
+    fun getNewBottles(userId: Long): List<Bottle> {
+        val user = userRepository.findByIdOrNull(userId) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
 
         return bottleRepository.findAllByTargetUserAndStatusAndNotExpired(
             user,
@@ -41,13 +40,12 @@ class BottleService(
     }
 
     @Transactional
-    fun acceptBottle(bottleId: Long) {
+    fun acceptBottle(userId: Long, bottleId: Long) {
         val bottle =
             bottleRepository.findByIdAndStatusAndNotExpired(bottleId, setOf(PingPongStatus.NONE), LocalDateTime.now())
                 ?: throw IllegalArgumentException("이미 떠내려간 보틀이에요")
 
-        // TODO User 회원 가입 기능 구현후 수정
-        val targetUser = userRepository.findByIdOrNull(1L) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
+        val targetUser = userRepository.findByIdOrNull(userId) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
         val sourceUser = userRepository.findByIdOrNull(bottle.sourceUser.id)
             ?: throw IllegalArgumentException("탈퇴한 회원이에요")
 
@@ -75,22 +73,20 @@ class BottleService(
     }
 
     @Transactional
-    fun refuseBottle(bottleId: Long) {
+    fun refuseBottle(userId: Long, bottleId: Long) {
         val bottle =
             bottleRepository.findByIdAndStatusAndNotExpired(bottleId, setOf(PingPongStatus.NONE), LocalDateTime.now())
                 ?: throw IllegalArgumentException("이미 떠내려간 보틀이에요")
 
-        // TODO User 회원 가입 기능 구현후 수정
-        val targetUser = userRepository.findByIdOrNull(1L) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
+        val targetUser = userRepository.findByIdOrNull(userId) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
         userRepository.findByIdOrNull(bottle.sourceUser.id) ?: throw IllegalArgumentException("탈퇴한 회원이에요")
 
         bottle.refuse(targetUser)
     }
 
     @Transactional(readOnly = true)
-    fun getPingPongBottles(): List<Bottle> {
-        // TODO User 회원 가입 기능 구현후 수정
-        val user = userRepository.findByIdOrNull(1L) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
+    fun getPingPongBottles(userId: Long): List<Bottle> {
+        val user = userRepository.findByIdOrNull(userId) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
 
         return bottleRepository.findAllByUserAndStatus(
             user,

--- a/src/main/kotlin/com/nexters/bottles/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/nexters/bottles/config/SwaggerConfig.kt
@@ -1,6 +1,7 @@
 package com.nexters.bottles.config
 
 import com.nexters.bottles.global.interceptor.AuthRequired
+import com.nexters.bottles.global.resolver.AuthUserId
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import springfox.documentation.builders.PathSelectors
@@ -22,6 +23,7 @@ class SwaggerConfig {
             .apis(RequestHandlerSelectors.basePackage("com.nexters.bottles"))
             .paths(PathSelectors.any())
             .build()
+            .ignoredParameterTypes(AuthUserId::class.java)
             .securityContexts(listOf(securityContext()))
             .securitySchemes(listOf(ApiKey("Authorization", "Authorization", "header")))
     }

--- a/src/main/kotlin/com/nexters/bottles/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/nexters/bottles/config/SwaggerConfig.kt
@@ -1,10 +1,15 @@
 package com.nexters.bottles.config
 
+import com.nexters.bottles.global.interceptor.AuthRequired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import springfox.documentation.builders.PathSelectors
 import springfox.documentation.builders.RequestHandlerSelectors
+import springfox.documentation.service.ApiKey
+import springfox.documentation.service.AuthorizationScope
+import springfox.documentation.service.SecurityReference
 import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spi.service.contexts.SecurityContext
 import springfox.documentation.spring.web.plugins.Docket
 
 @Configuration
@@ -17,5 +22,24 @@ class SwaggerConfig {
             .apis(RequestHandlerSelectors.basePackage("com.nexters.bottles"))
             .paths(PathSelectors.any())
             .build()
+            .securityContexts(listOf(securityContext()))
+            .securitySchemes(listOf(ApiKey("Authorization", "Authorization", "header")))
+    }
+
+    private fun securityContext(): SecurityContext? =
+        SecurityContext.builder()
+            .securityReferences(defaultAuth())
+            .operationSelector { operationContext ->
+                operationContext.requestMappingPattern().let { _ ->
+                    val handlerMethod = operationContext.findAnnotation(AuthRequired::class.java)
+                    !handlerMethod.isEmpty
+                }
+            }
+            .build()
+
+    private fun defaultAuth(): List<SecurityReference> {
+        val authorizationScope = AuthorizationScope("global", "accessEverything")
+        val authorizationScopes = arrayOf(authorizationScope)
+        return listOf(SecurityReference("Authorization", authorizationScopes))
     }
 }

--- a/src/main/kotlin/com/nexters/bottles/config/WebConfig.kt
+++ b/src/main/kotlin/com/nexters/bottles/config/WebConfig.kt
@@ -1,0 +1,23 @@
+package com.nexters.bottles.config
+
+import com.nexters.bottles.global.interceptor.AuthInterceptor
+import com.nexters.bottles.global.resolver.AuthUserIdArgumentResolver
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig(
+    private val authInterceptor: AuthInterceptor,
+    private val authUserIdArgumentResolver: AuthUserIdArgumentResolver
+) : WebMvcConfigurer {
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(authInterceptor)
+    }
+
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(authUserIdArgumentResolver)
+    }
+}

--- a/src/main/kotlin/com/nexters/bottles/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/nexters/bottles/global/exception/GlobalExceptionHandler.kt
@@ -18,4 +18,11 @@ class GlobalExceptionHandler {
         log.warn { "Error occured at path: ${request.requestURI}, message: ${e.message}" }
         return ErrorResponseDto(e.message)
     }
+
+    @ExceptionHandler(IllegalStateException::class)
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
+    fun handle(request: HttpServletRequest, e: IllegalStateException): ErrorResponseDto {
+        log.warn { "Error occured at path: ${request.requestURI}, message: ${e.message}" }
+        return ErrorResponseDto(e.message)
+    }
 }

--- a/src/main/kotlin/com/nexters/bottles/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/nexters/bottles/global/exception/GlobalExceptionHandler.kt
@@ -25,4 +25,11 @@ class GlobalExceptionHandler {
         log.warn { "Error occured at path: ${request.requestURI}, message: ${e.message}" }
         return ErrorResponseDto(e.message)
     }
+
+    @ExceptionHandler(UnauthorizedException::class)
+    @ResponseStatus(value = HttpStatus.UNAUTHORIZED)
+    fun handle(request: HttpServletRequest, e: UnauthorizedException): ErrorResponseDto {
+        log.warn { "Error occured at path: ${request.requestURI}, message: ${e.message}" }
+        return ErrorResponseDto(e.message)
+    }
 }

--- a/src/main/kotlin/com/nexters/bottles/global/exception/UnauthorizedException.kt
+++ b/src/main/kotlin/com/nexters/bottles/global/exception/UnauthorizedException.kt
@@ -1,0 +1,3 @@
+package com.nexters.bottles.global.exception
+
+class UnauthorizedException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/nexters/bottles/global/interceptor/AuthInterceptor.kt
+++ b/src/main/kotlin/com/nexters/bottles/global/interceptor/AuthInterceptor.kt
@@ -1,0 +1,26 @@
+package com.nexters.bottles.global.interceptor
+
+import com.nexters.bottles.auth.component.JwtTokenProvider
+import com.nexters.bottles.global.exception.UnauthorizedException
+import org.springframework.stereotype.Component
+import org.springframework.web.method.HandlerMethod
+import org.springframework.web.servlet.HandlerInterceptor
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@Component
+class AuthInterceptor(private val jwtTokenProvider: JwtTokenProvider) : HandlerInterceptor {
+
+    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+        if (handler !is HandlerMethod) {
+            return true;
+        }
+        if (handler.hasMethodAnnotation(AuthRequired::class.java)) {
+            val token = jwtTokenProvider.resolveToken(request)
+            if (token == null || !jwtTokenProvider.validateToken(token, isAccessToken = true)) {
+                throw UnauthorizedException("고객센터에 문의해주세요")
+            }
+        }
+        return true
+    }
+}

--- a/src/main/kotlin/com/nexters/bottles/global/interceptor/AuthRequired.kt
+++ b/src/main/kotlin/com/nexters/bottles/global/interceptor/AuthRequired.kt
@@ -1,0 +1,5 @@
+package com.nexters.bottles.global.interceptor
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class AuthRequired

--- a/src/main/kotlin/com/nexters/bottles/global/resolver/AuthUserId.kt
+++ b/src/main/kotlin/com/nexters/bottles/global/resolver/AuthUserId.kt
@@ -1,0 +1,5 @@
+package com.nexters.bottles.global.resolver
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class AuthUserId()

--- a/src/main/kotlin/com/nexters/bottles/global/resolver/AuthUserIdArgumentResolver.kt
+++ b/src/main/kotlin/com/nexters/bottles/global/resolver/AuthUserIdArgumentResolver.kt
@@ -1,0 +1,34 @@
+package com.nexters.bottles.global.resolver
+
+import com.nexters.bottles.auth.component.JwtTokenProvider
+import com.nexters.bottles.global.exception.UnauthorizedException
+import org.springframework.core.MethodParameter
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+import javax.servlet.http.HttpServletRequest
+
+@Component
+class AuthUserIdArgumentResolver(
+    private val jwtTokenProvider: JwtTokenProvider
+) : HandlerMethodArgumentResolver {
+
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return parameter.hasParameterAnnotation(AuthUserId::class.java)
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?
+    ): Any {
+        val request = webRequest.nativeRequest as HttpServletRequest
+        val token = jwtTokenProvider.resolveToken(request)
+        val userId = token?.takeIf { jwtTokenProvider.validateToken(it, isAccessToken = true) }
+            ?.let { jwtTokenProvider.getUserIdFromToken(it, isAccessToken = true) }
+        return userId ?: throw UnauthorizedException("고객센터에 문의해주세요")
+    }
+}

--- a/src/main/kotlin/com/nexters/bottles/user/controller/UserProfileController.kt
+++ b/src/main/kotlin/com/nexters/bottles/user/controller/UserProfileController.kt
@@ -1,9 +1,11 @@
 package com.nexters.bottles.user.controller
 
+import com.nexters.bottles.global.interceptor.AuthRequired
+import com.nexters.bottles.global.resolver.AuthUserId
+import com.nexters.bottles.user.facade.UserProfileFacade
 import com.nexters.bottles.user.facade.dto.ProfileChoiceResponseDto
 import com.nexters.bottles.user.facade.dto.RegisterIntroductionRequestDto
 import com.nexters.bottles.user.facade.dto.RegisterProfileRequestDto
-import com.nexters.bottles.user.facade.UserProfileFacade
 import com.nexters.bottles.user.facade.dto.UserProfileResponseDto
 import io.swagger.annotations.ApiOperation
 import org.springframework.web.bind.annotation.GetMapping
@@ -20,25 +22,31 @@ class UserProfileController(
 
     @ApiOperation("온보딩 프로필 등록하기")
     @PostMapping("/choice")
-    fun upsertProfile(@RequestBody registerProfileRequestDto: RegisterProfileRequestDto) {
-        profileFacade.upsertProfile(registerProfileRequestDto)
+    @AuthRequired
+    fun upsertProfile(@AuthUserId userId: Long, @RequestBody registerProfileRequestDto: RegisterProfileRequestDto) {
+        profileFacade.upsertProfile(userId, registerProfileRequestDto)
     }
 
     @ApiOperation("온보딩 선택지 조회하기 - 지역")
     @GetMapping("/choice")
-    fun getProfileChoiceList() : ProfileChoiceResponseDto {
+    fun getProfileChoiceList(): ProfileChoiceResponseDto {
         return profileFacade.getProfileChoice()
     }
 
     @ApiOperation("마이페이지 자기소개 등록하기")
     @PostMapping("/introduction")
-    fun upsertIntroduction(@RequestBody registerIntroductionRequestDto: RegisterIntroductionRequestDto) {
-        profileFacade.upsertIntroduction(registerIntroductionRequestDto)
+    @AuthRequired
+    fun upsertIntroduction(
+        @AuthUserId userId: Long,
+        @RequestBody registerIntroductionRequestDto: RegisterIntroductionRequestDto
+    ) {
+        profileFacade.upsertIntroduction(userId, registerIntroductionRequestDto)
     }
 
     @ApiOperation("마이페이지 내 프로필 조회하기")
     @GetMapping
-    fun getProfile(): UserProfileResponseDto {
-        return profileFacade.getProfile()
+    @AuthRequired
+    fun getProfile(@AuthUserId userId: Long): UserProfileResponseDto {
+        return profileFacade.getProfile(userId)
     }
 }

--- a/src/main/kotlin/com/nexters/bottles/user/domain/UserProfile.kt
+++ b/src/main/kotlin/com/nexters/bottles/user/domain/UserProfile.kt
@@ -5,7 +5,13 @@ import com.nexters.bottles.user.facade.dto.InterestDto
 import com.nexters.bottles.user.facade.dto.RegionDto
 import com.nexters.bottles.user.repository.converter.QuestionAndAnswerConverter
 import com.nexters.bottles.user.repository.converter.UserProfileSelectConverter
-import javax.persistence.*
+import javax.persistence.Convert
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.OneToOne
 
 @Entity
 class UserProfile(
@@ -15,14 +21,14 @@ class UserProfile(
 
     @OneToOne
     @JoinColumn(name = "user_id")
-    var user: User? = null,
+    val user: User,
 
     @Convert(converter = UserProfileSelectConverter::class)
     var profileSelect: UserProfileSelect? = null,
 
     @Convert(converter = QuestionAndAnswerConverter::class)
     var introduction: List<QuestionAndAnswer> = arrayListOf(),
-) :  BaseEntity()
+) : BaseEntity()
 
 data class UserProfileSelect(
     val mbti: String,

--- a/src/main/kotlin/com/nexters/bottles/user/facade/UserProfileFacade.kt
+++ b/src/main/kotlin/com/nexters/bottles/user/facade/UserProfileFacade.kt
@@ -6,6 +6,7 @@ import com.nexters.bottles.user.facade.dto.RegisterIntroductionRequestDto
 import com.nexters.bottles.user.facade.dto.RegisterProfileRequestDto
 import com.nexters.bottles.user.facade.dto.UserProfileResponseDto
 import com.nexters.bottles.user.service.UserProfileService
+import com.nexters.bottles.user.service.UserService
 import mu.KotlinLogging
 import org.springframework.stereotype.Component
 import regions
@@ -13,6 +14,7 @@ import regions
 @Component
 class UserProfileFacade(
     private val profileService: UserProfileService,
+    private val userService: UserService,
 ) {
 
     private val log = KotlinLogging.logger { }
@@ -52,9 +54,10 @@ class UserProfileFacade(
     fun getProfile(userId: Long): UserProfileResponseDto {
 
         val userProfile = profileService.findUserProfile(userId)
+        val user = userProfile?.user ?: userService.findById(userId)
         return UserProfileResponseDto(
-            userName = "테스트", // TODO 회원가입 기능 구현 후 수정
-            age = 20,
+            userName = user.name,
+            age = user.getKoreanAge(),
             introduction = userProfile?.introduction,
             profileSelect = userProfile?.profileSelect
         )

--- a/src/main/kotlin/com/nexters/bottles/user/facade/UserProfileFacade.kt
+++ b/src/main/kotlin/com/nexters/bottles/user/facade/UserProfileFacade.kt
@@ -1,9 +1,9 @@
 package com.nexters.bottles.user.facade
 
+import com.nexters.bottles.user.domain.UserProfileSelect
 import com.nexters.bottles.user.facade.dto.ProfileChoiceResponseDto
 import com.nexters.bottles.user.facade.dto.RegisterIntroductionRequestDto
 import com.nexters.bottles.user.facade.dto.RegisterProfileRequestDto
-import com.nexters.bottles.user.domain.UserProfileSelect
 import com.nexters.bottles.user.facade.dto.UserProfileResponseDto
 import com.nexters.bottles.user.service.UserProfileService
 import mu.KotlinLogging
@@ -15,13 +15,14 @@ class UserProfileFacade(
     private val profileService: UserProfileService,
 ) {
 
-    private val log = KotlinLogging.logger {  }
+    private val log = KotlinLogging.logger { }
 
-    fun upsertProfile(profileDto: RegisterProfileRequestDto) {
+    fun upsertProfile(userId: Long, profileDto: RegisterProfileRequestDto) {
         validateProfile(profileDto)
         val convertedProfileDto = convertProfileDto(profileDto)
 
         profileService.upsertProfile(
+            userId = userId,
             profileSelect = UserProfileSelect(
                 mbti = convertedProfileDto.mbti,
                 keyword = convertedProfileDto.keyword,
@@ -42,17 +43,17 @@ class UserProfileFacade(
         )
     }
 
-    fun upsertIntroduction(registerIntroductionRequestDto: RegisterIntroductionRequestDto) {
+    fun upsertIntroduction(userId: Long, registerIntroductionRequestDto: RegisterIntroductionRequestDto) {
         validateIntroduction(registerIntroductionRequestDto)
 
-        profileService.saveIntroduction(registerIntroductionRequestDto.introduction)
+        profileService.saveIntroduction(userId, registerIntroductionRequestDto.introduction)
     }
 
-    fun getProfile(): UserProfileResponseDto {
+    fun getProfile(userId: Long): UserProfileResponseDto {
 
-        val userProfile = profileService.findUserProfile(1L) // TODO: 회원 기능 구현후 수정
+        val userProfile = profileService.findUserProfile(userId)
         return UserProfileResponseDto(
-            userName = "테스트",
+            userName = "테스트", // TODO 회원가입 기능 구현 후 수정
             age = 20,
             introduction = userProfile?.introduction,
             profileSelect = userProfile?.profileSelect
@@ -63,8 +64,8 @@ class UserProfileFacade(
         require(profileDto.keyword.size <= 5) {
             "키워드는 5개 이하여야 해요"
         }
-        val interestCount = profileDto.interest.culture.size + profileDto.interest.sports.size
-        + profileDto.interest.entertainment.size + profileDto.interest.etc.size
+        val interestCount = profileDto.interest.culture.size + profileDto.interest.sports.size +
+                profileDto.interest.entertainment.size + profileDto.interest.etc.size
         require(interestCount <= 5) {
             "취미는 5개 이하여야 해요"
         }
@@ -80,12 +81,12 @@ class UserProfileFacade(
     }
 
     private fun convertProfileDto(profileDto: RegisterProfileRequestDto): RegisterProfileRequestDto {
-        when(profileDto.smoking) {
+        when (profileDto.smoking) {
             "전혀 피우지 않아요" -> profileDto.smoking = "흡연 안해요"
             "가끔 피워요" -> profileDto.smoking = "흡연은 가끔"
             "자주 피워요" -> profileDto.smoking = "흡연해요"
         }
-        when(profileDto.alcohol) {
+        when (profileDto.alcohol) {
             "한 방울도 마시지 않아요" -> profileDto.smoking = "술은 안해요"
             "때에 따라 적당히 즐겨요" -> profileDto.smoking = "술은 적당히"
             "자주 찾는 편이에요" -> profileDto.smoking = "술을 즐겨요"

--- a/src/main/kotlin/com/nexters/bottles/user/service/UserProfileService.kt
+++ b/src/main/kotlin/com/nexters/bottles/user/service/UserProfileService.kt
@@ -23,7 +23,6 @@ class UserProfileService(
         val user = userRepository.findByIdOrNull(userId) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
 
         profileRepository.findByUserId(user.id)?.let {
-            it.user = user
             it.profileSelect = profileSelect
         } ?: run {
             profileRepository.save(

--- a/src/main/kotlin/com/nexters/bottles/user/service/UserProfileService.kt
+++ b/src/main/kotlin/com/nexters/bottles/user/service/UserProfileService.kt
@@ -19,9 +19,8 @@ class UserProfileService(
     private val log = KotlinLogging.logger { }
 
     @Transactional
-    fun upsertProfile(profileSelect: UserProfileSelect) {
-        // TODO User 회원 가입 기능 구현후 수정
-        val user = userRepository.findByIdOrNull(1L) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
+    fun upsertProfile(userId: Long, profileSelect: UserProfileSelect) {
+        val user = userRepository.findByIdOrNull(userId) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
 
         profileRepository.findByUserId(user.id)?.let {
             it.user = user
@@ -37,9 +36,8 @@ class UserProfileService(
     }
 
     @Transactional
-    fun saveIntroduction(introduction: List<QuestionAndAnswer>) {
-        // TODO User 회원 가입 기능 구현후 수정
-        val user = userRepository.findByIdOrNull(1L) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
+    fun saveIntroduction(userId: Long, introduction: List<QuestionAndAnswer>) {
+        val user = userRepository.findByIdOrNull(userId) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
 
         profileRepository.findByUserId(user.id)?.let {
             it.introduction = introduction

--- a/src/main/kotlin/com/nexters/bottles/user/service/UserService.kt
+++ b/src/main/kotlin/com/nexters/bottles/user/service/UserService.kt
@@ -5,9 +5,9 @@ import com.nexters.bottles.user.domain.User
 import com.nexters.bottles.user.domain.enum.Gender
 import com.nexters.bottles.user.repository.UserRepository
 import mu.KotlinLogging
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 
 @Service
 class UserService(
@@ -18,7 +18,7 @@ class UserService(
 
     @Transactional
     fun findUserOrSignUp(userInfoResponse: KakaoUserInfoResponse): User {
-        userRepository.findByPhoneNumber(userInfoResponse.kakao_account.phone_number)?.let {user ->
+        userRepository.findByPhoneNumber(userInfoResponse.kakao_account.phone_number)?.let { user ->
             log.info { "전화번호 ${userInfoResponse.kakao_account.phone_number} 유저 존재하여 조회 후 반환" }
             return user
         } ?: run {
@@ -26,12 +26,20 @@ class UserService(
 
             return userRepository.save(
                 User(
-                    birthdate = userInfoResponse.kakao_account.birthDate ?: throw IllegalArgumentException("생년월일 정보를 확인해주세요"),
+                    birthdate = userInfoResponse.kakao_account.birthDate
+                        ?: throw IllegalArgumentException("생년월일 정보를 확인해주세요"),
                     name = userInfoResponse.kakao_account.name,
                     phoneNumber = userInfoResponse.kakao_account.phone_number,
-                    gender = Gender.fromString(userInfoResponse.kakao_account.gender) ?: throw IllegalArgumentException("성별을 확인해주세요")
+                    gender = Gender.fromString(userInfoResponse.kakao_account.gender) ?: throw IllegalArgumentException(
+                        "성별을 확인해주세요"
+                    )
                 )
             )
         }
+    }
+
+    @Transactional(readOnly = true)
+    fun findById(userId: Long): User {
+        return userRepository.findByIdOrNull(userId) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ webclient:
 spring:
   profiles: develop
   datasource:
-    url: jdbc:mysql://mysql:3306/${DB_DATABASE}?allowPublicKeyRetrieval=true&useSSL=false
+    url: jdbc:mysql://mysql:3306/${DB_DATABASE}?allowPublicKeyRetrieval=true&useSSL=false&useUnicode=true&characterEncoding=utf8
     username: ${DB_USER_NAME}
     password: ${DB_PASSWORD}
 

--- a/src/main/resources/sql/ddl/table_query.sql
+++ b/src/main/resources/sql/ddl/table_query.sql
@@ -4,10 +4,10 @@ CREATE TABLE user
     name         VARCHAR(255) DEFAULT NULL,
     birthdate    DATE         DEFAULT NULL,
     kakao_id     VARCHAR(255) DEFAULT NULL,
-    phone_number VARCHAR(255) DEFAULT NULL  comment 'ex) 01012345678',
+    phone_number VARCHAR(255) DEFAULT NULL comment 'ex) 01012345678',
     gender       VARCHAR(10)  DEFAULT 'MALE',
-    created_at   TIMESTAMP    DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    updated_at   TIMESTAMP    DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL
+    created_at   DATETIME     DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at   DATETIME     DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL
 );
 
 CREATE TABLE user_profile
@@ -22,16 +22,16 @@ CREATE TABLE user_profile
 
 CREATE TABLE bottle
 (
-    id                  BIGINT AUTO_INCREMENT PRIMARY KEY,
-    target_user_id      BIGINT                                NOT NULL,
-    target_user_select  BOOLEAN  DEFAULT FALSE                NOT NULL
-    source_user_id      BIGINT                                NOT NULL,
-    source_user_select  BOOLEAN  DEFAULT FALSE                NOT NULL
-    expired_at          DATETIME                              NOT NULL,
-    stopped_user_id     BIGINT,
-    ping_pong_status    VARCHAR(20) DEFAULT 'NONE'            NOT NULL,
-    created_at          DATETIME    DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    updated_at          DATETIME    DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL
+    id                 BIGINT AUTO_INCREMENT PRIMARY KEY,
+    target_user_id     BIGINT                                NOT NULL,
+    target_user_select BOOLEAN     DEFAULT FALSE             NOT NULL,
+    source_user_id     BIGINT                                NOT NULL,
+    source_user_select BOOLEAN     DEFAULT FALSE             NOT NULL,
+    expired_at         DATETIME                              NOT NULL,
+    stopped_user_id    BIGINT,
+    ping_pong_status   VARCHAR(20) DEFAULT 'NONE'            NOT NULL,
+    created_at         DATETIME    DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at         DATETIME    DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL
 );
 
 CREATE TABLE letter
@@ -52,8 +52,9 @@ CREATE TABLE question
     question VARCHAR(255) NOT NULL
 );
 
-CREATE TABLE refresh_tokens (
-    id BIGINT   AUTO_INCREMENT PRIMARY KEY,
+CREATE TABLE refresh_tokens
+(
+    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
     user_id     BIGINT                             NOT NULL,
     token       VARCHAR(2048)                      NOT NULL,
     expiry_date DATETIME                           NOT NULL,


### PR DESCRIPTION
## 💡 이슈 번호
close: #68 

## ✨ 작업 내용
- 인증이 필요한 컨트롤러 메서드에 `@AuthRequired` 어노테이션을 붙이면 인터셉터에서 Authroization 헤더의 토큰을 검증하도록 했습니다.
- userId가 필요한 컨트롤러 메서드의 파라미터에 `@AuthUserId`를 사용하면 ArgumentResolver를 통해 userId를 파라미터에 바인딩하도록 했습니다. 
- user 관련해서 TODO로 남겨두었던 부분 수정했습니다.

## 🚀 전달 사항
- 스웨거에서 Authorization 헤더를 설정할 수 있도록 설정 파일을 수정했습니다.
- 컨트롤러에 메서드에서 `@AuthUserId` 로 파라미터 받는 것은 스웨거에서 입력할 수 없도록(안보이도록) 설정해야해서 계속 찾아봤는데, 어떻게 하는지 모르겠어요.. 혹시 아시나요??
<img width="1408" alt="스크린샷 2024-07-29 오후 6 47 03" src="https://github.com/user-attachments/assets/1feaad9e-ab9d-4f4b-ab2a-0b8d8a2a523a">
