### PR TITLE
[Feature/89] 사진 등록 API 수정 및 사진 공유 여부를 선택하는 API를 구현한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ out/
 
 ### file ###
 application-local.yml
+
+uploads

--- a/src/main/kotlin/com/nexters/bottles/bottle/controller/BottleController.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/controller/BottleController.kt
@@ -15,9 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.multipart.MultipartFile
 
 @RestController
 @RequestMapping("/api/v1/bottles")
@@ -90,13 +88,6 @@ class BottleController(
     @AuthRequired
     fun getBottlePingPong(@AuthUserId userId: Long, @PathVariable bottleId: Long): BottlePingpongResponseDto {
         return bottleFacade.getBottlePingPong(userId, bottleId)
-    }
-
-    @ApiOperation("보틀 보관함 - 사진 전송하기")
-    @PostMapping("/ping-pong/{bottleId}/images")
-    @AuthRequired
-    fun uploadImage(@AuthUserId userId: Long, @PathVariable bottleId: Long, @RequestPart file: MultipartFile) {
-        bottleFacade.uploadImage(userId, bottleId, file)
     }
 
     @ApiOperation("최종 선택하기")

--- a/src/main/kotlin/com/nexters/bottles/bottle/controller/BottleController.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/controller/BottleController.kt
@@ -2,6 +2,7 @@ package com.nexters.bottles.bottle.controller
 
 import com.nexters.bottles.bottle.facade.BottleFacade
 import com.nexters.bottles.bottle.facade.dto.BottleDetailResponseDto
+import com.nexters.bottles.bottle.facade.dto.BottleImageShareRequest
 import com.nexters.bottles.bottle.facade.dto.BottleListResponseDto
 import com.nexters.bottles.bottle.facade.dto.BottleMatchRequest
 import com.nexters.bottles.bottle.facade.dto.BottlePingpongResponseDto
@@ -88,6 +89,17 @@ class BottleController(
     @AuthRequired
     fun getBottlePingPong(@AuthUserId userId: Long, @PathVariable bottleId: Long): BottlePingpongResponseDto {
         return bottleFacade.getBottlePingPong(userId, bottleId)
+    }
+
+    @ApiOperation("사진 공유 선택하기")
+    @PostMapping("/ping-pong/{bottleId}/image")
+    @AuthRequired
+    fun selectShareImage(
+        @AuthUserId userId: Long,
+        @PathVariable bottleId: Long,
+        @RequestBody bottleImageShareRequest: BottleImageShareRequest
+    ) {
+        bottleFacade.selectShareImage(userId, bottleId, bottleImageShareRequest.willShare)
     }
 
     @ApiOperation("최종 선택하기")

--- a/src/main/kotlin/com/nexters/bottles/bottle/domain/Letter.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/domain/Letter.kt
@@ -52,6 +52,10 @@ class Letter(
     fun markUnread() {
         isReadByOtherUser = false
     }
+
+    fun shareImage(willShare: Boolean) {
+        isShowImage = willShare
+    }
 }
 
 data class LetterQuestionAndAnswer(

--- a/src/main/kotlin/com/nexters/bottles/bottle/domain/Letter.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/domain/Letter.kt
@@ -32,7 +32,7 @@ class Letter(
     var letters: List<LetterQuestionAndAnswer> = arrayListOf(),
 
     @Column
-    var imageUrl: String? = null,
+    var isShowImage: Boolean? = null,
 
     @Column
     var isReadByOtherUser: Boolean = false,
@@ -51,10 +51,6 @@ class Letter(
 
     fun markUnread() {
         isReadByOtherUser = false
-    }
-
-    fun uploadImage(imageUrl: String) {
-        this.imageUrl = imageUrl
     }
 }
 

--- a/src/main/kotlin/com/nexters/bottles/bottle/facade/BottleFacade.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/facade/BottleFacade.kt
@@ -188,6 +188,19 @@ class BottleFacade(
         )
     }
 
+    fun selectShareImage(userId: Long, bottleId: Long, willShare: Boolean) {
+        val user = userService.findById(userId)
+        val pingPongBottle = bottleService.getPingPongBottle(bottleId)
+
+        val letter = letterService.findLetter(pingPongBottle, user)
+        letter.shareImage(willShare)
+        letter.markUnread()
+
+        if (!willShare) {
+            pingPongBottle.stop(user)
+        }
+    }
+
     fun selectMatch(userId: Long, bottleId: Long, willMatch: Boolean) {
         val user = userService.findById(userId)
 

--- a/src/main/kotlin/com/nexters/bottles/bottle/facade/BottleFacade.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/facade/BottleFacade.kt
@@ -181,8 +181,8 @@ class BottleFacade(
     ): Photo {
 
         return Photo(
-            myImageUrl = myProfile.imageUrlOriginal,
-            otherImageUrl = otherProfile.imageUrlOriginal,
+            myImageUrl = myProfile.imageUrl,
+            otherImageUrl = otherProfile.imageUrl,
             shouldAnswer = myLetter.isShowImage == null,
             changeFinished = (myLetter.isShowImage != null) && (otherLetter.isShowImage != null)
         )

--- a/src/main/kotlin/com/nexters/bottles/bottle/facade/dto/BottleImageShareRequest.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/facade/dto/BottleImageShareRequest.kt
@@ -1,0 +1,5 @@
+package com.nexters.bottles.bottle.facade.dto
+
+data class BottleImageShareRequest(
+    val willShare: Boolean = true,
+)

--- a/src/main/kotlin/com/nexters/bottles/bottle/service/FileService.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/service/FileService.kt
@@ -6,4 +6,5 @@ import java.net.URL
 interface FileService {
 
     fun upload(file: MultipartFile, path: String): URL
+    fun upload(filePath: String, key: String): URL
 }

--- a/src/main/kotlin/com/nexters/bottles/bottle/service/LetterService.kt
+++ b/src/main/kotlin/com/nexters/bottles/bottle/service/LetterService.kt
@@ -30,12 +30,4 @@ class LetterService(
             ?: throw IllegalArgumentException("고객센터에 문의해주세요")
         otherUserLetter.markRead()
     }
-
-    @Transactional
-    fun uploadImageURl(bottle: Bottle, user: User, imageUrl: String) {
-        val letter = letterRepository.findByBottleAndUser(bottle, user)
-            ?: throw IllegalArgumentException("고객센터에 문의해주세요")
-        letter.uploadImage(imageUrl)
-        letter.markUnread()
-    }
 }

--- a/src/main/kotlin/com/nexters/bottles/infra/AmazonS3FileService.kt
+++ b/src/main/kotlin/com/nexters/bottles/infra/AmazonS3FileService.kt
@@ -3,7 +3,7 @@ package com.nexters.bottles.infra
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.ObjectMetadata
 import com.amazonaws.services.s3.model.PutObjectRequest
-import com.nexters.bottles.bottle.service.FileService
+import com.nexters.bottles.user.service.FileService
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile

--- a/src/main/kotlin/com/nexters/bottles/infra/AmazonS3FileService.kt
+++ b/src/main/kotlin/com/nexters/bottles/infra/AmazonS3FileService.kt
@@ -7,7 +7,9 @@ import com.nexters.bottles.bottle.service.FileService
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
+import java.io.File
 import java.net.URL
+import java.nio.file.Files
 
 @Component
 class AmazonS3FileService(
@@ -17,7 +19,7 @@ class AmazonS3FileService(
     private val bucket: String,
 ) : FileService {
 
-    override fun upload(file: MultipartFile, path: String): URL {
+    override fun upload(file: MultipartFile, key: String): URL {
         val objectMetadata = ObjectMetadata().apply {
             this.contentType = file.contentType
             this.contentLength = file.size
@@ -25,11 +27,28 @@ class AmazonS3FileService(
 
         val putObjectRequest = PutObjectRequest(
             bucket,
-            path,
+            key,
             file.inputStream,
-            objectMetadata,
+            objectMetadata
         )
         amazonS3.putObject(putObjectRequest)
-        return amazonS3.getUrl(bucket, path)
+        return amazonS3.getUrl(bucket, key)
+    }
+
+    override fun upload(filePath: String, key: String): URL {
+        val file = File(filePath)
+        val objectMetadata = ObjectMetadata().apply {
+            this.contentType = Files.probeContentType(file.toPath())
+            this.contentLength = file.length()
+        }
+
+        val putObjectRequest = PutObjectRequest(
+            bucket,
+            key,
+            file.inputStream().buffered(),
+            objectMetadata
+        )
+        amazonS3.putObject(putObjectRequest)
+        return amazonS3.getUrl(bucket, key)
     }
 }

--- a/src/main/kotlin/com/nexters/bottles/user/component/ImageProcessor.kt
+++ b/src/main/kotlin/com/nexters/bottles/user/component/ImageProcessor.kt
@@ -1,0 +1,30 @@
+package com.nexters.bottles.user.component
+
+import org.springframework.stereotype.Component
+import java.awt.image.BufferedImage
+import java.awt.image.ConvolveOp
+import java.awt.image.Kernel
+import java.io.File
+import javax.imageio.ImageIO
+import kotlin.math.sqrt
+
+@Component
+class ImageProcessor {
+
+    fun blurImage(file: File): BufferedImage {
+        val image = ImageIO.read(file)
+        val blurredImage = applyGaussianBlur(image)
+        return blurredImage
+    }
+
+    private fun applyGaussianBlur(image: BufferedImage): BufferedImage {
+        val matrix = FloatArray(225) { 1 / 225f }
+        val size = sqrt(matrix.size.toDouble()).toInt()
+        val kernel = Kernel(size, size, matrix)
+        val convolveOp = ConvolveOp(kernel, ConvolveOp.EDGE_NO_OP, null)
+
+        val blurredImage = BufferedImage(image.width, image.height, image.type)
+        convolveOp.filter(image, blurredImage)
+        return blurredImage
+    }
+}

--- a/src/main/kotlin/com/nexters/bottles/user/component/ImageUploader.kt
+++ b/src/main/kotlin/com/nexters/bottles/user/component/ImageUploader.kt
@@ -26,7 +26,7 @@ class ImageUploader(
             Files.createDirectories(uploadDir)
         }
 
-        val originalFilePath = uploadDir.resolve("original_" + LocalDateTime.now() + file.originalFilename!!)
+        val originalFilePath = uploadDir.resolve("original_" + LocalDateTime.now() + file.originalFilename)
         Files.copy(file.inputStream, originalFilePath)
 
         val blurredImage = imageProcessor.blurImage(File(originalFilePath.toString()))

--- a/src/main/kotlin/com/nexters/bottles/user/component/ImageUploader.kt
+++ b/src/main/kotlin/com/nexters/bottles/user/component/ImageUploader.kt
@@ -1,6 +1,6 @@
 package com.nexters.bottles.user.component
 
-import com.nexters.bottles.bottle.service.FileService
+import com.nexters.bottles.user.service.FileService
 import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
 import java.io.File

--- a/src/main/kotlin/com/nexters/bottles/user/component/ImageUploader.kt
+++ b/src/main/kotlin/com/nexters/bottles/user/component/ImageUploader.kt
@@ -1,0 +1,44 @@
+package com.nexters.bottles.user.component
+
+import com.nexters.bottles.bottle.service.FileService
+import org.springframework.stereotype.Component
+import org.springframework.web.multipart.MultipartFile
+import java.io.File
+import java.net.URL
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.time.LocalDateTime
+import javax.imageio.ImageIO
+
+@Component
+class ImageUploader(
+    private val imageProcessor: ImageProcessor,
+    private val fileService: FileService
+) {
+
+    fun upload(file: MultipartFile, path: String): URL {
+        return fileService.upload(file, path)
+    }
+
+    fun uploadWithBlur(file: MultipartFile, path: String): URL {
+        val uploadDir = Paths.get("uploads")
+        if (!Files.exists(uploadDir)) {
+            Files.createDirectories(uploadDir)
+        }
+
+        val originalFilePath = uploadDir.resolve("original_" + LocalDateTime.now() + file.originalFilename!!)
+        Files.copy(file.inputStream, originalFilePath)
+
+        val blurredImage = imageProcessor.blurImage(File(originalFilePath.toString()))
+
+        val blurredFilePath = uploadDir.resolve("blurred_" + LocalDateTime.now() + file.originalFilename)
+        ImageIO.write(blurredImage, "jpg", File(blurredFilePath.toString()))
+
+        val imageUrlBlur = fileService.upload(blurredFilePath.toString(), "blurred_${path}")
+
+        Files.deleteIfExists(originalFilePath)
+        Files.deleteIfExists(blurredFilePath)
+
+        return imageUrlBlur
+    }
+}

--- a/src/main/kotlin/com/nexters/bottles/user/controller/UserProfileController.kt
+++ b/src/main/kotlin/com/nexters/bottles/user/controller/UserProfileController.kt
@@ -12,7 +12,9 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
 
 @RestController
 @RequestMapping("/api/v1/profile")
@@ -48,5 +50,12 @@ class UserProfileController(
     @AuthRequired
     fun getProfile(@AuthUserId userId: Long): UserProfileResponseDto {
         return profileFacade.getProfile(userId)
+    }
+
+    @ApiOperation("마이페이지 사진 등록하기")
+    @PostMapping("/images")
+    @AuthRequired
+    fun uploadImage(@AuthUserId userId: Long, @RequestPart file: MultipartFile) {
+        profileFacade.uploadImage(userId, file)
     }
 }

--- a/src/main/kotlin/com/nexters/bottles/user/domain/UserProfile.kt
+++ b/src/main/kotlin/com/nexters/bottles/user/domain/UserProfile.kt
@@ -28,6 +28,10 @@ class UserProfile(
 
     @Convert(converter = QuestionAndAnswerConverter::class)
     var introduction: List<QuestionAndAnswer> = arrayListOf(),
+
+    var imageUrlOriginal: String? = null,
+
+    var imageUrlBlur: String? = null,
 ) : BaseEntity()
 
 data class UserProfileSelect(

--- a/src/main/kotlin/com/nexters/bottles/user/domain/UserProfile.kt
+++ b/src/main/kotlin/com/nexters/bottles/user/domain/UserProfile.kt
@@ -29,9 +29,9 @@ class UserProfile(
     @Convert(converter = QuestionAndAnswerConverter::class)
     var introduction: List<QuestionAndAnswer> = arrayListOf(),
 
-    var imageUrlOriginal: String? = null,
+    var imageUrl: String? = null,
 
-    var imageUrlBlur: String? = null,
+    var blurredImageUrl: String? = null,
 ) : BaseEntity()
 
 data class UserProfileSelect(

--- a/src/main/kotlin/com/nexters/bottles/user/facade/UserProfileFacade.kt
+++ b/src/main/kotlin/com/nexters/bottles/user/facade/UserProfileFacade.kt
@@ -1,6 +1,6 @@
 package com.nexters.bottles.user.facade
 
-import com.nexters.bottles.bottle.service.FileService
+import com.nexters.bottles.user.component.ImageUploader
 import com.nexters.bottles.user.domain.UserProfileSelect
 import com.nexters.bottles.user.facade.dto.ProfileChoiceResponseDto
 import com.nexters.bottles.user.facade.dto.RegisterIntroductionRequestDto
@@ -19,7 +19,7 @@ import java.time.format.DateTimeFormatter
 class UserProfileFacade(
     private val profileService: UserProfileService,
     private val userService: UserService,
-    private val fileService: FileService,
+    private val imageUploader: ImageUploader,
 ) {
 
     private val log = KotlinLogging.logger { }
@@ -106,10 +106,10 @@ class UserProfileFacade(
     fun uploadImage(userId: Long, file: MultipartFile) {
         val me = userService.findById(userId)
         val path = makePathWithUserId(file, me.id)
-        val imageUrlOriginal = fileService.upload(file, path)
-        // TODO blur 처리된 Image 저장
-        val imageUrlBlur = fileService.upload(file, path)
-        profileService.uploadImageUrl(me, imageUrlOriginal.toString(), imageUrlBlur.toString())
+        val originalImageUrl = imageUploader.upload(file, path);
+        val blurredImageUrl = imageUploader.uploadWithBlur(file, path);
+
+        profileService.uploadImageUrl(me, originalImageUrl.toString(), blurredImageUrl.toString())
     }
 
     private fun makePathWithUserId(

--- a/src/main/kotlin/com/nexters/bottles/user/facade/UserProfileFacade.kt
+++ b/src/main/kotlin/com/nexters/bottles/user/facade/UserProfileFacade.kt
@@ -115,8 +115,8 @@ class UserProfileFacade(
     private fun makePathWithUserId(
         file: MultipartFile,
         userId: Long
-    ) = file.originalFilename + FILE_NAME_DELIMITER +
-            LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss")) + FILE_NAME_DELIMITER + userId
+    ) = "" + userId + FILE_NAME_DELIMITER + LocalDateTime.now()
+        .format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss")) + FILE_NAME_DELIMITER + file.originalFilename
 
     companion object {
         private const val FILE_NAME_DELIMITER = "_"

--- a/src/main/kotlin/com/nexters/bottles/user/service/FileService.kt
+++ b/src/main/kotlin/com/nexters/bottles/user/service/FileService.kt
@@ -1,4 +1,4 @@
-package com.nexters.bottles.bottle.service
+package com.nexters.bottles.user.service
 
 import org.springframework.web.multipart.MultipartFile
 import java.net.URL

--- a/src/main/kotlin/com/nexters/bottles/user/service/UserProfileService.kt
+++ b/src/main/kotlin/com/nexters/bottles/user/service/UserProfileService.kt
@@ -57,10 +57,10 @@ class UserProfileService(
     }
 
     @Transactional
-    fun uploadImageUrl(user: User, imageUrlOriginal: String, imageUrlBlur: String) {
+    fun uploadImageUrl(user: User, imageUrl: String, blurredImageUrl: String) {
         profileRepository.findByUserId(user.id)?.let {
-            it.imageUrlOriginal = imageUrlOriginal
-            it.imageUrlBlur = imageUrlBlur
+            it.imageUrl = imageUrl
+            it.blurredImageUrl = blurredImageUrl
         } ?: throw IllegalArgumentException("고객센터에 문의해주세요")
     }
 }

--- a/src/main/kotlin/com/nexters/bottles/user/service/UserProfileService.kt
+++ b/src/main/kotlin/com/nexters/bottles/user/service/UserProfileService.kt
@@ -1,6 +1,7 @@
 package com.nexters.bottles.user.service
 
 import com.nexters.bottles.user.domain.QuestionAndAnswer
+import com.nexters.bottles.user.domain.User
 import com.nexters.bottles.user.domain.UserProfile
 import com.nexters.bottles.user.domain.UserProfileSelect
 import com.nexters.bottles.user.repository.UserProfileRepository
@@ -53,5 +54,13 @@ class UserProfileService(
     @Transactional(readOnly = true)
     fun findUserProfile(userId: Long): UserProfile? {
         return profileRepository.findByUserId(userId)
+    }
+
+    @Transactional
+    fun uploadImageUrl(user: User, imageUrlOriginal: String, imageUrlBlur: String) {
+        profileRepository.findByUserId(user.id)?.let {
+            it.imageUrlOriginal = imageUrlOriginal
+            it.imageUrlBlur = imageUrlBlur
+        } ?: throw IllegalArgumentException("고객센터에 문의해주세요")
     }
 }

--- a/src/main/resources/sql/ddl/table_query.sql
+++ b/src/main/resources/sql/ddl/table_query.sql
@@ -17,8 +17,8 @@ CREATE TABLE user_profile
     user_id           BIGINT                             NOT NULL,
     profile_select    JSON,
     introduction      JSON,
-    image_url         TEXT,
-    blurred_image_url TEXT,
+    image_url         VARCHAR(2048),
+    blurred_image_url VARCHAR(2048),
     created_at        DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at        DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL
 );

--- a/src/main/resources/sql/ddl/table_query.sql
+++ b/src/main/resources/sql/ddl/table_query.sql
@@ -12,12 +12,14 @@ CREATE TABLE user
 
 CREATE TABLE user_profile
 (
-    id             BIGINT AUTO_INCREMENT PRIMARY KEY,
-    user_id        BIGINT                             NOT NULL,
-    profile_select JSON,
-    introduction   JSON,
-    created_at     DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    updated_at     DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL
+    id                 BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id            BIGINT                             NOT NULL,
+    profile_select     JSON,
+    introduction       JSON,
+    image_url_original TEXT,
+    image_url_blur     TEXT,
+    created_at         DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at         DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL
 );
 
 CREATE TABLE bottle
@@ -40,7 +42,7 @@ CREATE TABLE letter
     bottle_id             BIGINT                             NOT NULL,
     user_id               BIGINT                             NOT NULL,
     letters               JSON                               NOT NULL,
-    image_url             TEXT,
+    is_show_image         BOOLEAN  DEFAULT FALSE             NOT NULL,
     is_read_by_other_user BOOLEAN  DEFAULT FALSE             NOT NULL,
     created_at            DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at            DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL
@@ -62,13 +64,13 @@ CREATE TABLE refresh_tokens
     updated_at  DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL
 );
 
-CREATE TABLE auth_sms (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    phone_number VARCHAR(255) NOT NULL,
-    auth_code VARCHAR(255) NOT NULL
-    expired_at DATETIME NOT NULL,
-    created_at  DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    updated_at  DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL
+CREATE TABLE auth_sms
+(
+    id           BIGINT AUTO_INCREMENT PRIMARY KEY,
+    phone_number VARCHAR(255)                       NOT NULL,
+    auth_code    VARCHAR(255)                       NOT NULL expired_at DATETIME NOT NULL,
+    created_at   DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at   DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL
 );
 
-CREATE INDEX idx_phone_number ON auth_sms(phone_number);
+CREATE INDEX idx_phone_number ON auth_sms (phone_number);

--- a/src/main/resources/sql/ddl/table_query.sql
+++ b/src/main/resources/sql/ddl/table_query.sql
@@ -12,14 +12,14 @@ CREATE TABLE user
 
 CREATE TABLE user_profile
 (
-    id                 BIGINT AUTO_INCREMENT PRIMARY KEY,
-    user_id            BIGINT                             NOT NULL,
-    profile_select     JSON,
-    introduction       JSON,
-    image_url_original TEXT,
-    image_url_blur     TEXT,
-    created_at         DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    updated_at         DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL
+    id                BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id           BIGINT                             NOT NULL,
+    profile_select    JSON,
+    introduction      JSON,
+    image_url         TEXT,
+    blurred_image_url TEXT,
+    created_at        DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at        DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL
 );
 
 CREATE TABLE bottle


### PR DESCRIPTION
## 💡 이슈 번호
close: #89 

## ✨ 작업 내용
- 핑퐁 과정에서 하던 이미지 등록 API를 UserProfileController로 옮겼습니다.
- Letter 테이블에 있던 image_url을 UserProfile 테이블로 옮겼습니다.
- Letter 테이블에는 사진을 공유할지에 대한 여부를 저장하는 is_show_image 필드를 추가했습니다.
- 핑퐁 과정에서 사진을 공유할지에 대한 여부를 선택하는 API를 추가했습니다. -> 이에 따라 핑퐁 조회 API도 살짝 수정되었습니다.

## 🚀 전달 사항
- 이미지 블러 처리하려면 요청으로 들어온 이미지 파일을 임시로 서버에 저장해서 작업을 해야하더라구요. 그래서 `uploads` 폴더에 저장했다가 작업이 끝나면 삭제하도록 했습니다! 다른 좋은 방법이 있다면 알려주세요 ㅎㅎ