### PR TITLE
[Feature/88] 자기소개 작성 여부 조회 API를 구현한다

### DIFF
--- a/src/main/kotlin/com/nexters/bottles/user/controller/UserProfileController.kt
+++ b/src/main/kotlin/com/nexters/bottles/user/controller/UserProfileController.kt
@@ -3,6 +3,7 @@ package com.nexters.bottles.user.controller
 import com.nexters.bottles.global.interceptor.AuthRequired
 import com.nexters.bottles.global.resolver.AuthUserId
 import com.nexters.bottles.user.facade.UserProfileFacade
+import com.nexters.bottles.user.facade.dto.ExistIntroductionResponse
 import com.nexters.bottles.user.facade.dto.ProfileChoiceResponseDto
 import com.nexters.bottles.user.facade.dto.RegisterIntroductionRequestDto
 import com.nexters.bottles.user.facade.dto.RegisterProfileRequestDto
@@ -48,5 +49,12 @@ class UserProfileController(
     @AuthRequired
     fun getProfile(@AuthUserId userId: Long): UserProfileResponseDto {
         return profileFacade.getProfile(userId)
+    }
+
+    @ApiOperation("자기소개 작성 여부 조회하기")
+    @GetMapping("/introduction/exist")
+    @AuthRequired
+    fun existIntroduction(@AuthUserId userId: Long): ExistIntroductionResponse {
+        return profileFacade.existIntroduction(userId)
     }
 }

--- a/src/main/kotlin/com/nexters/bottles/user/facade/UserProfileFacade.kt
+++ b/src/main/kotlin/com/nexters/bottles/user/facade/UserProfileFacade.kt
@@ -1,6 +1,7 @@
 package com.nexters.bottles.user.facade
 
 import com.nexters.bottles.user.domain.UserProfileSelect
+import com.nexters.bottles.user.facade.dto.ExistIntroductionResponse
 import com.nexters.bottles.user.facade.dto.ProfileChoiceResponseDto
 import com.nexters.bottles.user.facade.dto.RegisterIntroductionRequestDto
 import com.nexters.bottles.user.facade.dto.RegisterProfileRequestDto
@@ -15,6 +16,7 @@ import regions
 class UserProfileFacade(
     private val profileService: UserProfileService,
     private val userService: UserService,
+    private val userProfileService: UserProfileService,
 ) {
 
     private val log = KotlinLogging.logger { }
@@ -96,5 +98,10 @@ class UserProfileFacade(
             "자주 찾는 편이에요" -> profileDto.smoking = "술을 즐겨요"
         }
         return profileDto
+    }
+
+    fun existIntroduction(userId: Long): ExistIntroductionResponse {
+        val userProfile = userProfileService.findUserProfile(userId) ?: throw IllegalArgumentException("고객센터에 문의해주세요")
+        return ExistIntroductionResponse(isExist = userProfile.introduction.isEmpty())
     }
 }

--- a/src/main/kotlin/com/nexters/bottles/user/facade/dto/ExistIntroductionResponse.kt
+++ b/src/main/kotlin/com/nexters/bottles/user/facade/dto/ExistIntroductionResponse.kt
@@ -1,0 +1,5 @@
+package com.nexters.bottles.user.facade.dto
+
+data class ExistIntroductionResponse(
+    val isExist: Boolean
+)


### PR DESCRIPTION
## 💡 이슈 번호
close: #88 

## ✨ 작업 내용
- 메인페이지에서 자기소개 작성 여부를 조회하는 API를 구현했습니다.

## 🚀 전달 사항
- 자기소개 작성 여부를 boolean 값으로 전달하도록 했는데, 그냥 자기소개를 조회하는 API로 만들어야 하나 고민이 되네요! 그래서 클라이언트 단에서 빈배열인지 확인해서 처리하는게 맞는지 🤔