### PR TITLE
[Feature/130] 액세스 토큰 만료 로직 추가 및 토큰 만료시키는 API를 구현한다

### DIFF
--- a/src/main/kotlin/com/nexters/bottles/admin/controller/AdminController.kt
+++ b/src/main/kotlin/com/nexters/bottles/admin/controller/AdminController.kt
@@ -3,12 +3,13 @@ package com.nexters.bottles.admin.controller
 import com.nexters.bottles.admin.facade.AdminFacade
 import com.nexters.bottles.admin.facade.dto.CreateCustomTokenRequest
 import com.nexters.bottles.admin.facade.dto.CustomTokenResponse
+import com.nexters.bottles.admin.facade.dto.ExpireTokenRequest
+import com.nexters.bottles.admin.facade.dto.ForceAfterProfileResponse
 import com.nexters.bottles.global.interceptor.AuthRequired
 import com.nexters.bottles.global.resolver.AuthUserId
 import io.swagger.annotations.ApiOperation
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
-import com.nexters.bottles.admin.facade.dto.ForceAfterProfileResponse
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -32,5 +33,21 @@ class AdminController(
         @RequestBody createCustomTokenRequest: CreateCustomTokenRequest
     ): CustomTokenResponse {
         return adminFacade.createCustomValidityToken(userId, createCustomTokenRequest)
+    }
+
+    @ApiOperation("액세스 토큰 만료시키기")
+    @PostMapping("/expire/access-token")
+    fun expireAccessToken(
+        @RequestBody expireTokenRequest: ExpireTokenRequest
+    ) {
+        return adminFacade.expireToken(expireTokenRequest, true)
+    }
+
+    @ApiOperation("리프레시 토큰 만료시키기")
+    @PostMapping("/expire/refresh-token")
+    fun expireRefreshToken(
+        @RequestBody expireTokenRequest: ExpireTokenRequest
+    ) {
+        return adminFacade.expireToken(expireTokenRequest, false)
     }
 }

--- a/src/main/kotlin/com/nexters/bottles/admin/facade/AdminFacade.kt
+++ b/src/main/kotlin/com/nexters/bottles/admin/facade/AdminFacade.kt
@@ -3,6 +3,7 @@ package com.nexters.bottles.admin.facade
 import com.nexters.bottles.admin.component.TestJwtTokenProvider
 import com.nexters.bottles.admin.facade.dto.CreateCustomTokenRequest
 import com.nexters.bottles.admin.facade.dto.CustomTokenResponse
+import com.nexters.bottles.admin.facade.dto.ExpireTokenRequest
 import com.nexters.bottles.admin.facade.dto.ForceAfterProfileResponse
 import com.nexters.bottles.admin.service.AdminService
 import com.nexters.bottles.auth.component.JwtTokenProvider
@@ -96,5 +97,15 @@ class AdminFacade(
         )
         adminService.saveMockUser(mockUser)
         return mockUser
+    }
+
+    fun expireToken(expireTokenRequest: ExpireTokenRequest, isAccessToken: Boolean) {
+        if (isAccessToken) {
+            adminService.expireAccessToken(expireTokenRequest.token)
+        } else {
+            val userId = jwtTokenProvider.getUserIdFromToken(expireTokenRequest.token, false)
+                ?: throw IllegalArgumentException("유효하지 않은 리프레시 토큰입니다")
+            adminService.expireRefreshToken(expireTokenRequest.token, userId)
+        }
     }
 }

--- a/src/main/kotlin/com/nexters/bottles/admin/facade/dto/ExpireTokenRequest.kt
+++ b/src/main/kotlin/com/nexters/bottles/admin/facade/dto/ExpireTokenRequest.kt
@@ -1,0 +1,5 @@
+package com.nexters.bottles.admin.facade.dto
+
+data class ExpireTokenRequest(
+    val token: String
+)

--- a/src/main/kotlin/com/nexters/bottles/admin/service/AdminService.kt
+++ b/src/main/kotlin/com/nexters/bottles/admin/service/AdminService.kt
@@ -1,5 +1,8 @@
 package com.nexters.bottles.admin.service
 
+import com.nexters.bottles.auth.domain.BlackList
+import com.nexters.bottles.auth.repository.BlackListRepository
+import com.nexters.bottles.auth.repository.RefreshTokenRepository
 import com.nexters.bottles.user.domain.User
 import com.nexters.bottles.user.domain.UserProfile
 import com.nexters.bottles.user.repository.UserProfileRepository
@@ -11,6 +14,8 @@ import org.springframework.transaction.annotation.Transactional
 class AdminService(
     private val userRepository: UserRepository,
     private val userProfileRepository: UserProfileRepository,
+    private val blackListRepository: BlackListRepository,
+    private val refreshTokenRepository: RefreshTokenRepository
 ) {
 
     @Transactional
@@ -21,5 +26,17 @@ class AdminService(
     @Transactional
     fun saveMockProfile(mockUserProfile: UserProfile) {
         userProfileRepository.save(mockUserProfile)
+    }
+
+    @Transactional
+    fun expireAccessToken(token: String) {
+        val blackList = BlackList(expiredAccessToken = token)
+        blackListRepository.save(blackList)
+    }
+
+    @Transactional
+    fun expireRefreshToken(token: String, userId: Long) {
+        refreshTokenRepository.findAllByUserId(userId)
+            .forEach { refreshTokenRepository.deleteById(it.id) }
     }
 }

--- a/src/main/kotlin/com/nexters/bottles/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/nexters/bottles/auth/controller/AuthController.kt
@@ -4,13 +4,16 @@ import com.nexters.bottles.auth.facade.AuthFacade
 import com.nexters.bottles.auth.facade.dto.AuthSmsRequest
 import com.nexters.bottles.auth.facade.dto.KakaoSignInUpRequest
 import com.nexters.bottles.auth.facade.dto.KakaoSignInUpResponse
+import com.nexters.bottles.auth.facade.dto.RefreshAccessTokenResponse
 import com.nexters.bottles.auth.facade.dto.SendSmsResponse
 import com.nexters.bottles.auth.facade.dto.SignUpRequest
 import com.nexters.bottles.auth.facade.dto.SignUpResponse
 import com.nexters.bottles.auth.facade.dto.SmsSendRequest
-import com.nexters.bottles.auth.facade.dto.*
+import com.nexters.bottles.auth.facade.dto.SmsSignInRequest
+import com.nexters.bottles.auth.facade.dto.SmsSignInResponse
 import com.nexters.bottles.global.interceptor.AuthRequired
 import com.nexters.bottles.global.interceptor.RefreshAuthRequired
+import com.nexters.bottles.global.resolver.AccessToken
 import com.nexters.bottles.global.resolver.AuthUserId
 import com.nexters.bottles.global.resolver.RefreshTokenUserId
 import io.swagger.annotations.ApiOperation
@@ -65,8 +68,8 @@ class AuthController(
     @ApiOperation("로그아웃하기")
     @PostMapping("/logout")
     @AuthRequired
-    fun logout(@AuthUserId userId: Long) {
-        authFacade.logout(userId)
+    fun logout(@AuthUserId userId: Long, @AccessToken accessToken: String) {
+        authFacade.logout(userId, accessToken)
     }
 
     @ApiOperation("회원 탈퇴하기")

--- a/src/main/kotlin/com/nexters/bottles/auth/domain/BlackList.kt
+++ b/src/main/kotlin/com/nexters/bottles/auth/domain/BlackList.kt
@@ -1,0 +1,16 @@
+package com.nexters.bottles.auth.domain
+
+import com.nexters.bottles.global.BaseEntity
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+
+@Entity
+class BlackList(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    val expiredAccessToken: String,
+) : BaseEntity()

--- a/src/main/kotlin/com/nexters/bottles/auth/facade/AuthFacade.kt
+++ b/src/main/kotlin/com/nexters/bottles/auth/facade/AuthFacade.kt
@@ -3,8 +3,18 @@ package com.nexters.bottles.auth.facade
 import com.nexters.bottles.auth.component.AuthCodeGenerator
 import com.nexters.bottles.auth.component.JwtTokenProvider
 import com.nexters.bottles.auth.component.NaverSmsEncoder
-import com.nexters.bottles.auth.facade.dto.*
+import com.nexters.bottles.auth.facade.dto.AuthSmsRequest
+import com.nexters.bottles.auth.facade.dto.KakaoSignInUpResponse
+import com.nexters.bottles.auth.facade.dto.KakaoUserInfoResponse
+import com.nexters.bottles.auth.facade.dto.MessageDTO
+import com.nexters.bottles.auth.facade.dto.RefreshAccessTokenResponse
+import com.nexters.bottles.auth.facade.dto.SendSmsResponse
+import com.nexters.bottles.auth.facade.dto.SignUpRequest
+import com.nexters.bottles.auth.facade.dto.SignUpResponse
+import com.nexters.bottles.auth.facade.dto.SmsSignInRequest
+import com.nexters.bottles.auth.facade.dto.SmsSignInResponse
 import com.nexters.bottles.auth.service.AuthSmsService
+import com.nexters.bottles.auth.service.BlackListService
 import com.nexters.bottles.auth.service.RefreshTokenService
 import com.nexters.bottles.infra.WebClientAdapter
 import com.nexters.bottles.user.service.UserService
@@ -17,6 +27,7 @@ import java.time.LocalDateTime
 class AuthFacade(
     private val userService: UserService,
     private val authSmsService: AuthSmsService,
+    private val blackListService: BlackListService,
     private val refreshTokenService: RefreshTokenService,
     private val webClientAdapter: WebClientAdapter,
     private val jwtTokenProvider: JwtTokenProvider,
@@ -88,8 +99,8 @@ class AuthFacade(
         lastAuthSms.validate(lastAuthSms.authCode)
     }
 
-    fun logout(userId: Long) {
-        //TODO: 액세스 토큰에 관해 블랙리스트 운영할지 말지 고민중
+    fun logout(userId: Long, accessToken: String) {
+        blackListService.add(accessToken)
         refreshTokenService.delete(userId)
     }
 

--- a/src/main/kotlin/com/nexters/bottles/auth/repository/BlackListRepository.kt
+++ b/src/main/kotlin/com/nexters/bottles/auth/repository/BlackListRepository.kt
@@ -1,0 +1,9 @@
+package com.nexters.bottles.auth.repository
+
+import com.nexters.bottles.auth.domain.BlackList
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface BlackListRepository : JpaRepository<BlackList, Long> {
+
+    fun findByExpiredAccessToken(token: String): BlackList?
+}

--- a/src/main/kotlin/com/nexters/bottles/auth/service/BlackListService.kt
+++ b/src/main/kotlin/com/nexters/bottles/auth/service/BlackListService.kt
@@ -1,0 +1,18 @@
+package com.nexters.bottles.auth.service
+
+import com.nexters.bottles.auth.domain.BlackList
+import com.nexters.bottles.auth.repository.BlackListRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class BlackListService(
+    private val blackListRepository: BlackListRepository
+) {
+
+    @Transactional
+    fun add(accessToken: String) {
+        val blackList = BlackList(expiredAccessToken = accessToken)
+        blackListRepository.save(blackList)
+    }
+}

--- a/src/main/kotlin/com/nexters/bottles/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/nexters/bottles/config/SwaggerConfig.kt
@@ -2,6 +2,7 @@ package com.nexters.bottles.config
 
 import com.nexters.bottles.global.interceptor.AuthRequired
 import com.nexters.bottles.global.interceptor.RefreshAuthRequired
+import com.nexters.bottles.global.resolver.AccessToken
 import com.nexters.bottles.global.resolver.AuthUserId
 import com.nexters.bottles.global.resolver.RefreshTokenUserId
 import org.springframework.context.annotation.Bean
@@ -25,7 +26,7 @@ class SwaggerConfig {
             .apis(RequestHandlerSelectors.basePackage("com.nexters.bottles"))
             .paths(PathSelectors.any())
             .build()
-            .ignoredParameterTypes(AuthUserId::class.java, RefreshTokenUserId::class.java)
+            .ignoredParameterTypes(AuthUserId::class.java, RefreshTokenUserId::class.java, AccessToken::class.java)
             .securityContexts(listOf(securityContext()))
             .securitySchemes(listOf(ApiKey("Authorization", "Authorization", "header")))
     }

--- a/src/main/kotlin/com/nexters/bottles/config/WebConfig.kt
+++ b/src/main/kotlin/com/nexters/bottles/config/WebConfig.kt
@@ -2,6 +2,7 @@ package com.nexters.bottles.config
 
 import com.nexters.bottles.global.interceptor.AuthInterceptor
 import com.nexters.bottles.global.interceptor.RefreshAuthInterceptor
+import com.nexters.bottles.global.resolver.AccessTokenArgumentResolver
 import com.nexters.bottles.global.resolver.AuthUserIdArgumentResolver
 import com.nexters.bottles.global.resolver.RefreshTokenArgumentResolver
 import org.springframework.context.annotation.Configuration
@@ -15,6 +16,7 @@ class WebConfig(
     private val refreshAuthInterceptor: RefreshAuthInterceptor,
     private val authUserIdArgumentResolver: AuthUserIdArgumentResolver,
     private val refreshAuthUserIdArgumentResolver: RefreshTokenArgumentResolver,
+    private val accessTokenArgumentResolver: AccessTokenArgumentResolver,
 ) : WebMvcConfigurer {
 
     override fun addInterceptors(registry: InterceptorRegistry) {
@@ -25,5 +27,6 @@ class WebConfig(
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
         resolvers.add(authUserIdArgumentResolver)
         resolvers.add(refreshAuthUserIdArgumentResolver)
+        resolvers.add(accessTokenArgumentResolver)
     }
 }

--- a/src/main/kotlin/com/nexters/bottles/global/resolver/AccessToken.kt
+++ b/src/main/kotlin/com/nexters/bottles/global/resolver/AccessToken.kt
@@ -1,0 +1,5 @@
+package com.nexters.bottles.global.resolver
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class AccessToken()

--- a/src/main/kotlin/com/nexters/bottles/global/resolver/AccessTokenArgumentResolver.kt
+++ b/src/main/kotlin/com/nexters/bottles/global/resolver/AccessTokenArgumentResolver.kt
@@ -1,0 +1,32 @@
+package com.nexters.bottles.global.resolver
+
+import com.nexters.bottles.auth.component.JwtTokenProvider
+import com.nexters.bottles.global.exception.UnauthorizedException
+import org.springframework.core.MethodParameter
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+import javax.servlet.http.HttpServletRequest
+
+@Component
+class AccessTokenArgumentResolver(
+    private val jwtTokenProvider: JwtTokenProvider
+) : HandlerMethodArgumentResolver {
+
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return parameter.hasParameterAnnotation(AccessToken::class.java)
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?
+    ): Any {
+        val request = webRequest.nativeRequest as HttpServletRequest
+        val token = jwtTokenProvider.resolveToken(request)
+        return token ?: throw UnauthorizedException("고객센터에 문의해주세요")
+    }
+}

--- a/src/main/resources/sql/ddl/table_query.sql
+++ b/src/main/resources/sql/ddl/table_query.sql
@@ -79,4 +79,12 @@ CREATE TABLE auth_sms
     updated_at   DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL
 );
 
+CREATE TABLE black_list
+(
+    id                   BIGINT AUTO_INCREMENT PRIMARY KEY,
+    expired_access_token VARCHAR(2048)                      NOT NULL,
+    created_at           DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at           DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL
+);
+
 CREATE INDEX idx_phone_number ON auth_sms (phone_number);


### PR DESCRIPTION
## 💡 이슈 번호
close: #130 

## ✨ 작업 내용
- 로그아웃 시 액세스토큰을 블랙리스트에 저장하여 토큰이 만료되도록 하는 로직을 추가했습니다.
- 액세스 토큰, 리프레시 토큰을 만료시키는 테스트 API를 구현했습니다.

## 🚀 전달 사항
