### PR TITLE
[Fix/143] docker-compose.yml에 fcm admin 파일 volume을 설정한다

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,9 +29,11 @@ services:
       NAVER_SMS_API_KEY: ${NAVER_SMS_API_KEY}
       NAVER_SMS_SECRET_KEY: ${NAVER_SMS_SECRET_KEY}
       NAVER_SMS_SENDER_PHONE: ${NAVER_SMS_SENDER_PHONE}
-      FCM_ADMIN_KEY_PATH: ${FCM_ADMIN_KEY_PATH}
+      FCM_ADMIN_KEY_PATH: /app/config/bottles-firebase-adminsdk.json
     ports:
       - "8080:8080"
+    volumes:
+      - ${FCM_ADMIN_KEY_PATH}:/app/config/bottles-firebase-adminsdk.json
     depends_on:
       - db
 


### PR DESCRIPTION
## 💡 이슈 번호
close: #143 

## ✨ 작업 내용
- docker-compose.yml에 fcm admin 파일 volume을 설정했습니다.
- 도커에서 실행하는거라 인스턴스에 있는 파일을 못읽어와서 실행이 안됐어요.

## 🚀 전달 사항
