### PR TITLE
[Feature/160] 같은 분 내에 들어오는 요청은 같은 토큰 제공

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/admin/component/TestJwtTokenProvider.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/admin/component/TestJwtTokenProvider.kt
@@ -7,7 +7,9 @@ import io.jsonwebtoken.security.Keys
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.time.Duration
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 @Component
 class TestJwtTokenProvider(
@@ -27,7 +29,11 @@ class TestJwtTokenProvider(
         userId: Long,
         accessTokenValidityInMilliseconds: Long
     ): String {
-        val now = LocalDateTime.now()
+        val nowLocalDateTime = LocalDateTime.now()
+        val now = LocalDateTime.of(
+            LocalDate.now(),
+            LocalTime.of(nowLocalDateTime.hour, nowLocalDateTime.minute)
+        )
         val expiryDate = now.plus(Duration.ofMillis(accessTokenValidityInMilliseconds))
 
         return Jwts.builder()
@@ -39,7 +45,11 @@ class TestJwtTokenProvider(
     }
 
     fun upsertRefreshToken(userId: Long, refreshTokenValidityInMilliseconds: Long): String {
-        val now = LocalDateTime.now()
+        val nowLocalDateTime = LocalDateTime.now()
+        val now = LocalDateTime.of(
+            LocalDate.now(),
+            LocalTime.of(nowLocalDateTime.hour, nowLocalDateTime.minute)
+        )
         val expiryDate = now.plus(Duration.ofMillis(refreshTokenValidityInMilliseconds))
 
         val token = Jwts.builder()

--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/component/JwtTokenProvider.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/component/JwtTokenProvider.kt
@@ -7,9 +7,7 @@ import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
-import java.time.Duration
-import java.time.LocalDateTime
-import java.time.ZoneId
+import java.time.*
 import java.util.*
 import javax.servlet.http.HttpServletRequest
 
@@ -35,7 +33,11 @@ class JwtTokenProvider(
     private val refreshKey = Keys.hmacShaKeyFor(refreshTokenSecretKey.toByteArray())
 
     fun createAccessToken(userId: Long): String {
-        val now = LocalDateTime.now()
+        val nowLocalDateTime = LocalDateTime.now()
+        val now = LocalDateTime.of(
+            LocalDate.now(),
+            LocalTime.of(nowLocalDateTime.hour, nowLocalDateTime.minute)
+        )
         val expiryDate = now.plus(Duration.ofMillis(accessTokenValidityInMilliseconds))
 
         return Jwts.builder()
@@ -47,7 +49,11 @@ class JwtTokenProvider(
     }
 
     fun upsertRefreshToken(userId: Long): String {
-        val now = LocalDateTime.now()
+        val nowLocalDateTime = LocalDateTime.now()
+        val now = LocalDateTime.of(
+            LocalDate.now(),
+            LocalTime.of(nowLocalDateTime.hour, nowLocalDateTime.minute)
+        )
         val expiryDate = now.plus(Duration.ofMillis(refreshTokenValidityInMilliseconds))
 
         val token = Jwts.builder()


### PR DESCRIPTION
## 💡 이슈 번호
close: #160 

## ✨ 작업 내용
 같은 분 내에 들어오는 요청은 같은 토큰 제공

## 🚀 전달 사항
LocalDateTime이 나노초까지 들어가는데, 나노초가 달라져도 서명이 달라져 다른 토큰을 발급하게 됩니다. 클라이언트에서 토큰이 만료했을 경우, api에서 리프레시 api를 요청합니다. 이때 병렬로 api를 요청하는 화면에서는 병렬로 요청하게되는데 그럼 한 api를 제외하고 나머지는 실패하게 됩니다. 이 문제를 수정하고자, 같은 '분' 내에 들어온 요청은 같은 토큰을 발행합니다