### PR TITLE
[Feature/166] 유저 마지막 활성 시간 기록하기

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacade.kt
@@ -12,6 +12,7 @@ import com.nexters.bottles.api.bottle.facade.dto.PingPongLetter
 import com.nexters.bottles.api.bottle.facade.dto.PingPongListResponse
 import com.nexters.bottles.api.bottle.facade.dto.PingPongUserProfile
 import com.nexters.bottles.api.bottle.facade.dto.RegisterLetterRequest
+import com.nexters.bottles.api.user.component.event.dto.UserApplicationEventDto
 import com.nexters.bottles.app.bottle.domain.Bottle
 import com.nexters.bottles.app.bottle.domain.Letter
 import com.nexters.bottles.app.bottle.domain.enum.BottleStatus
@@ -22,6 +23,7 @@ import com.nexters.bottles.app.user.domain.User
 import com.nexters.bottles.app.user.domain.UserProfile
 import com.nexters.bottles.app.user.service.UserService
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -31,6 +33,7 @@ class BottleFacade(
     private val bottleService: BottleService,
     private val letterService: LetterService,
     private val userService: UserService,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 
     @Value("\${matching.isActive}")
     private val isActiveMatching: Boolean,
@@ -51,7 +54,14 @@ class BottleFacade(
         return BottleListResponse(
             randomBottles = randomBottles,
             sentBottles = sentBottles
-        )
+        ).also {
+            applicationEventPublisher.publishEvent(
+                UserApplicationEventDto(
+                    userId = user.id,
+                    basedAt = LocalDateTime.now(),
+                )
+            )
+        }
     }
 
     private fun toBottleDto(bottle: Bottle): BottleDto {

--- a/api/src/main/kotlin/com/nexters/bottles/api/config/AsyncConfig.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/config/AsyncConfig.kt
@@ -1,0 +1,25 @@
+package com.nexters.bottles.api.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
+
+
+@Configuration
+@EnableAsync
+class AsyncConfig {
+
+    @Bean
+    fun taskExecutor(): Executor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = 5
+        executor.maxPoolSize = 10
+        executor.setQueueCapacity(25)
+        executor.setWaitForTasksToCompleteOnShutdown(true)
+        executor.setAwaitTerminationSeconds(30)
+        executor.initialize()
+        return executor
+    }
+}

--- a/api/src/main/kotlin/com/nexters/bottles/api/user/component/event/UserApplicationEventListener.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/user/component/event/UserApplicationEventListener.kt
@@ -1,0 +1,22 @@
+package com.nexters.bottles.api.user.component.event
+
+import com.nexters.bottles.api.user.component.event.dto.UserApplicationEventDto
+import com.nexters.bottles.app.user.service.UserService
+import mu.KotlinLogging
+import org.springframework.context.event.EventListener
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+
+@Component
+class UserApplicationEventListener(
+    private val userService: UserService,
+) {
+
+    private val log = KotlinLogging.logger {  }
+
+    @Async
+    @EventListener
+    fun handleCustomEvent(event: UserApplicationEventDto) {
+        userService.updateLastActivatedAt(event.userId, event.basedAt)
+    }
+}

--- a/api/src/main/kotlin/com/nexters/bottles/api/user/component/event/dto/UserApplicationEventDto.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/user/component/event/dto/UserApplicationEventDto.kt
@@ -1,0 +1,9 @@
+package com.nexters.bottles.api.user.component.event.dto
+
+import java.time.LocalDateTime
+
+data class UserApplicationEventDto(
+    val userId: Long,
+    val basedAt: LocalDateTime,
+) {
+}

--- a/api/src/main/resources/sql/ddl/table_query.sql
+++ b/api/src/main/resources/sql/ddl/table_query.sql
@@ -1,16 +1,17 @@
 CREATE TABLE user
 (
-    id           BIGINT AUTO_INCREMENT PRIMARY KEY,
-    name         VARCHAR(255) DEFAULT NULL,
-    birthdate    DATE         DEFAULT NULL,
-    kakao_id     VARCHAR(255) DEFAULT NULL,
-    phone_number VARCHAR(255) DEFAULT NULL comment 'ex) 01012345678',
-    gender       VARCHAR(10)  DEFAULT 'MALE',
-    sign_up_type VARCHAR(20)  DEFAULT 'NORMAL'                                      NOT NULL,
-    deleted      BOOLEAN      DEFAULT FALSE                                         NOT NULL,
-    deleted_at   DATETIME     DEFAULT CURRENT_TIMESTAMP,
-    created_at   DATETIME     DEFAULT CURRENT_TIMESTAMP                             NOT NULL,
-    updated_at   DATETIME     DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL
+    id                  BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name                VARCHAR(255) DEFAULT NULL,
+    birthdate           DATE         DEFAULT NULL,
+    kakao_id            VARCHAR(255) DEFAULT NULL,
+    phone_number        VARCHAR(255) DEFAULT NULL comment 'ex) 01012345678',
+    gender              VARCHAR(10)  DEFAULT 'MALE',
+    sign_up_type        VARCHAR(20)  DEFAULT 'NORMAL'                                      NOT NULL,
+    deleted             BOOLEAN      DEFAULT FALSE                                         NOT NULL,
+    deleted_at          DATETIME     DEFAULT CURRENT_TIMESTAMP,
+    last_activated_at   DATETIME     DEFAULT CURRENT_TIMESTAMP comment '유저의 최근 활성 시간으로, 보틀 목록 조회하기 api 요청시 갱신',
+    created_at          DATETIME     DEFAULT CURRENT_TIMESTAMP                             NOT NULL,
+    updated_at          DATETIME     DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL
 ) AUTO_INCREMENT = 10;
 
 CREATE TABLE user_profile

--- a/app/src/main/kotlin/com/nexters/bottles/app/user/domain/User.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/user/domain/User.kt
@@ -42,7 +42,8 @@ class User(
 
     var deletedAt: LocalDateTime? = null,
 
-    ) : BaseEntity() {
+    var lastActivatedAt: LocalDateTime = LocalDateTime.now(),
+) : BaseEntity() {
 
     fun getKoreanAge(): Int {
         return LocalDate.now().year - birthdate.year + 1
@@ -51,5 +52,9 @@ class User(
     fun softDelete() {
         this.deleted = true
         this.deletedAt = LocalDateTime.now()
+    }
+
+    fun updateLastActivatedAt(basedAt: LocalDateTime) {
+        this.lastActivatedAt = basedAt
     }
 }

--- a/app/src/main/kotlin/com/nexters/bottles/app/user/service/UserService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/user/service/UserService.kt
@@ -12,6 +12,7 @@ import mu.KotlinLogging
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
 class UserService(
@@ -91,5 +92,12 @@ class UserService(
     @Transactional(readOnly = true)
     fun findAllByNotDeleted(): List<User> {
         return userRepository.findAllByDeletedFalse()
+    }
+
+    @Transactional
+    fun updateLastActivatedAt(userId: Long, basedAt: LocalDateTime) {
+        userRepository.findByIdOrNull(userId)?.let {user ->
+            user.updateLastActivatedAt(basedAt)
+        }
     }
 }

--- a/app/src/main/resources/application-dev.yml
+++ b/app/src/main/resources/application-dev.yml
@@ -1,5 +1,6 @@
 server:
   port: 8080
+  shutdown: graceful
 
 spring:
   jpa:


### PR DESCRIPTION
## 💡 이슈 번호
close: #166 

## ✨ 작업 내용
유저 마지막 활성 시간 기록하기

## 🚀 전달 사항
![image](https://github.com/user-attachments/assets/2f8fe8df-3700-460f-942d-a50b627ef782)
모래사장(홈)에서 쓰는 api의 시간을 활성시간으로 기록하려합니다

``` sql
ALTER TABLE user
ADD COLUMN last_activated_at DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT '유저의 최근 활성 시간으로, 보틀 목록 조회하기 API 요청 시 갱신';
```