### PR TITLE
[Feature/172] 이미지 블러 처리 효과를 강화한다.

### DIFF
--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/domain/Bottle.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/domain/Bottle.kt
@@ -33,7 +33,7 @@ class Bottle(
     var likeMessage: String? = null,
 
     @Column
-    val expiredAt: LocalDateTime = LocalDateTime.now().plusDays(1),
+    var expiredAt: LocalDateTime = LocalDateTime.now().plusDays(1),
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "stopped_user_id")
@@ -52,11 +52,12 @@ class Bottle(
     var pingPongStatus: PingPongStatus = PingPongStatus.NONE,
 ) : BaseEntity() {
 
-    fun sendLikeMessage(from: User, to: User, likeMessage: String) {
+    fun sendLikeMessage(from: User, to: User, likeMessage: String, now: LocalDateTime) {
         this.targetUser = to
         this.sourceUser = from
         this.likeMessage = likeMessage
         this.bottleStatus = BottleStatus.SENT
+        this.expiredAt = now.plusDays(1)
     }
 
     fun startPingPong() {

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleService.kt
@@ -66,7 +66,8 @@ class BottleService(
                 bottle.sendLikeMessage(
                     from = targetUser,
                     to = sourceUser,
-                    likeMessage = likeMessage
+                    likeMessage = likeMessage,
+                    LocalDateTime.now()
                 )
             }
 

--- a/app/src/main/kotlin/com/nexters/bottles/app/common/component/ImageProcessor.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/common/component/ImageProcessor.kt
@@ -18,10 +18,10 @@ class ImageProcessor {
     }
 
     private fun applyGaussianBlur(image: BufferedImage): BufferedImage {
-        val matrix = FloatArray(225) { 1 / 225f }
+        val matrix = FloatArray(1225) { 1 / 1225f }
         val size = sqrt(matrix.size.toDouble()).toInt()
         val kernel = Kernel(size, size, matrix)
-        val convolveOp = ConvolveOp(kernel, ConvolveOp.EDGE_NO_OP, null)
+        val convolveOp = ConvolveOp(kernel, ConvolveOp.EDGE_ZERO_FILL, null)
 
         val blurredImage = BufferedImage(image.width, image.height, image.type)
         convolveOp.filter(image, blurredImage)


### PR DESCRIPTION
## 💡 이슈 번호
close: #172 

## ✨ 작업 내용
- 이미지 블러 처리를 더 확실하게 했습니다.
- 랜덤 보틀에 호감을 보내면 상대방의 마음이 담긴 보틀에 넣어진 시점부터 유효기간이 24시간이 되어야해서, 호감을 보낼 때 유효기간을 재설정하도록 추가했습니다.

## 🚀 전달 사항
<img width="124" alt="스크린샷 2024-08-11 오전 11 07 39" src="https://github.com/user-attachments/assets/595c7eac-350c-42ec-a680-18f1d73ba237">

이제 누군지 못알아보겠죠?