### PR TITLE
[Feature/184] 핑퐁 조회 시 user id 데이터를 반환한다

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/dto/BottlePingPongResponse.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/dto/BottlePingPongResponse.kt
@@ -14,6 +14,7 @@ data class BottlePingPongResponse(
 )
 
 data class PingPongUserProfile(
+    val userId: Long,
     val userName: String,
     val age: Int,
     val profileSelect: UserProfileSelect? = null,

--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/dto/PingPongListResponse.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/dto/PingPongListResponse.kt
@@ -9,6 +9,7 @@ data class PingPongBottleDto(
     val id: Long,
     val isRead: Boolean,
     val userName: String,
+    val userId: Long,
     val age: Int,
     val mbti: String?,
     val keyword: List<String>?,


### PR DESCRIPTION
## 💡 이슈 번호
close: #184 

## ✨ 작업 내용
- 보틀 보관함 목록 조회, 보틀 핑퐁 조회하기 응답에 user id를 추가했습니다. 
- 보틀 보관함 목록 조회 시 신고한 유저는 안보이도록 했습니다.

## 🚀 전달 사항
