### PR TITLE
[Feature/186] jwt 생성시 나노초까지 같아야 같은 토큰을 발급하게 원복

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/admin/component/TestJwtTokenProvider.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/admin/component/TestJwtTokenProvider.kt
@@ -29,11 +29,7 @@ class TestJwtTokenProvider(
         userId: Long,
         accessTokenValidityInMilliseconds: Long
     ): String {
-        val nowLocalDateTime = LocalDateTime.now()
-        val now = LocalDateTime.of(
-            LocalDate.now(),
-            LocalTime.of(nowLocalDateTime.hour, nowLocalDateTime.minute)
-        )
+        val now = LocalDateTime.now()
         val expiryDate = now.plus(Duration.ofMillis(accessTokenValidityInMilliseconds))
 
         return Jwts.builder()
@@ -45,11 +41,7 @@ class TestJwtTokenProvider(
     }
 
     fun upsertRefreshToken(userId: Long, refreshTokenValidityInMilliseconds: Long): String {
-        val nowLocalDateTime = LocalDateTime.now()
-        val now = LocalDateTime.of(
-            LocalDate.now(),
-            LocalTime.of(nowLocalDateTime.hour, nowLocalDateTime.minute)
-        )
+        val now = LocalDateTime.now()
         val expiryDate = now.plus(Duration.ofMillis(refreshTokenValidityInMilliseconds))
 
         val token = Jwts.builder()

--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/component/JwtTokenProvider.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/component/JwtTokenProvider.kt
@@ -37,11 +37,7 @@ class JwtTokenProvider(
     private val refreshKey = Keys.hmacShaKeyFor(refreshTokenSecretKey.toByteArray())
 
     fun createAccessToken(userId: Long): String {
-        val nowLocalDateTime = LocalDateTime.now()
-        val now = LocalDateTime.of(
-            LocalDate.now(),
-            LocalTime.of(nowLocalDateTime.hour, nowLocalDateTime.minute)
-        )
+        val now = LocalDateTime.now()
         val expiryDate = now.plus(Duration.ofMillis(accessTokenValidityInMilliseconds))
 
         return Jwts.builder()
@@ -53,11 +49,7 @@ class JwtTokenProvider(
     }
 
     fun upsertRefreshToken(userId: Long): String {
-        val nowLocalDateTime = LocalDateTime.now()
-        val now = LocalDateTime.of(
-            LocalDate.now(),
-            LocalTime.of(nowLocalDateTime.hour, nowLocalDateTime.minute)
-        )
+        val now = LocalDateTime.now()
         val expiryDate = now.plus(Duration.ofMillis(refreshTokenValidityInMilliseconds))
 
         val token = Jwts.builder()


### PR DESCRIPTION
## 💡 이슈 번호
close: #186 

## ✨ 작업 내용
 jwt 생성시 나노초까지 같아야 같은 토큰을 발급하게 원복

## 🚀 전달 사항
