### PR TITLE
[Fix/188] 자기소개 작성 여부 조회 API를 수정한다

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/user/facade/UserProfileFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/user/facade/UserProfileFacade.kt
@@ -127,7 +127,7 @@ class UserProfileFacade(
 
     fun existIntroduction(userId: Long): ExistIntroductionResponse {
         val userProfile = profileService.findUserProfile(userId) ?: throw IllegalArgumentException("고객센터에 문의해주세요")
-        return ExistIntroductionResponse(isExist = userProfile.introduction.isEmpty())
+        return ExistIntroductionResponse(isExist = userProfile.introduction.isNotEmpty())
     }
 
     fun findUserInfo(userId: Long): UserInfoResponse {


### PR DESCRIPTION
## 💡 이슈 번호
close: #188 

## ✨ 작업 내용
- 자기소개 작성 여부를 반대로 반환해서 수정했습니다.

## 🚀 전달 사항
