### PR TITLE
[Feature/194] 테스트 계정 인증 로직을 수정한다

### DIFF
--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -116,6 +116,8 @@ jobs:
             echo "export NAVER_SMS_SENDER_PHONE=${{ secrets.NAVER_SMS_SENDER_PHONE }}" >> /home/${{ secrets.SERVER_USER_NAME }}/deploy/env_vars.sh
             
             echo "export FCM_ADMIN_KEY_PATH=${{ secrets.FCM_ADMIN_KEY_PATH }}" >> /home/${{ secrets.SERVER_USER_NAME }}/deploy/env_vars.sh
+            
+            echo "export SUPER_USER_NUMBER=${{ secrets.SUPER_USER_NUMBER }}" >> /home/${{ secrets.SERVER_USER_NAME }}/deploy/env_vars.sh
 
             export SERVER_USER_NAME=${{ secrets.SERVER_USER_NAME }}
 

--- a/app/src/main/resources/application-dev.yml
+++ b/app/src/main/resources/application-dev.yml
@@ -56,3 +56,5 @@ matching:
 
 firebase:
   service-account-key-path: ${FCM_ADMIN_KEY_PATH}
+
+super-user-number: ${SUPER_USER_NUMBER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       NAVER_SMS_SECRET_KEY: ${NAVER_SMS_SECRET_KEY}
       NAVER_SMS_SENDER_PHONE: ${NAVER_SMS_SENDER_PHONE}
       FCM_ADMIN_KEY_PATH: /app/config/bottles-firebase-adminsdk.json
+      SUPER_USER_NUMBER: ${SUPER_USER_NUMBER}
     ports:
       - "8080:8080"
     volumes:


### PR DESCRIPTION
## 💡 이슈 번호
close: #194 

## ✨ 작업 내용
- 테스트 계정을 환경변수로 빼서 관리하도록 했습니다.
- 테스트 계정일 경우 문자 인증 시 인증 번호를 새로 저장하지 않도록 로직을 수정했습니다. (기존에 저장해놓은 인증번호 하나만 가지고 있게 하기 위함)

## 🚀 전달 사항
- 환경 변수 secrets에 추가할게요!