### PR TITLE
[Fix/210] 매칭 유효기간 설정 수정 및 매칭 로직 수정한다

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacade.kt
@@ -46,8 +46,9 @@ class BottleFacade(
     fun getNewBottles(userId: Long): BottleListResponse {
         val user = userService.findByIdAndNotDeleted(userId)
         if (isActiveMatching) {
-            val matchingTime = LocalDateTime.now().with(LocalTime.of(18, 0))
-            bottleService.matchRandomBottle(user, matchingTime)
+            val matchingHour = 18
+//            val matchingTime = LocalDateTime.now().with(LocalTime.of(18, 0))
+            bottleService.matchRandomBottle(user, matchingHour)
                 ?.also {
                     applicationEventPublisher.publishEvent(
                         BottleApplicationEventDto(

--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacade.kt
@@ -47,7 +47,6 @@ class BottleFacade(
         val user = userService.findByIdAndNotDeleted(userId)
         if (isActiveMatching) {
             val matchingHour = 18
-//            val matchingTime = LocalDateTime.now().with(LocalTime.of(18, 0))
             bottleService.matchRandomBottle(user, matchingHour)
                 ?.also {
                     applicationEventPublisher.publishEvent(

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/repository/BottleMatchingRepository.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/repository/BottleMatchingRepository.kt
@@ -45,9 +45,8 @@ class BottleMatchingRepository(
             AND up.image_url IS NOT NULL 
             AND up.introduction IS NOT NULL 
             AND JSON_LENGTH(up.introduction) > 0 
-        LEFT JOIN bottle_history bh ON u.id = bh.matched_user_id 
-        WHERE bh.matched_user_id IS NULL 
-          AND u.id != :userId 
+        LEFT JOIN bottle_history bh ON bh.user_id = :userId AND bh.matched_user_id != u.id
+        WHERE u.id != :userId 
           AND u.gender != :gender 
           AND u.deleted = false 
           AND u.is_match_activated = true;


### PR DESCRIPTION
## 💡 이슈 번호
close: #210 

## ✨ 작업 내용
- 매칭 유효기간을 매칭 시간 24시간 뒤로 설정되도록 수정했습니다.
- 매칭 시간이 자정을 기준으로 다르게 설정되어 매칭이 제대로 되지 않는 문제가 있어 수정했습니다.

## 🚀 전달 사항
매칭 시간이 15일 오후 6시라고 할 때,
15일 밤 12시 전에 들어오면 매칭을 받지만, 16일로 넘어간 후 들어오면 매칭 시간이 16일 오후 6시로 설정되어 매칭을 받지 못하는 문제

따라서 16일 오후 6시 전에 들어오면 매칭 시간이 15일 오후 6시로 설정되도록 매칭 시간을 조정했습니다.