### PR TITLE
[Feature/223] 핑퐁 조회 API MatchStatus 상태값을 추가한다

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacade.kt
@@ -207,6 +207,8 @@ class BottleFacade(
         val otherUser = bottle.findOtherUser(me)
         val myLetter = letterService.findLetter(bottle, me)
         val otherLetter = letterService.findLetter(bottle, otherUser)
+        // TODO 출시 후 제거
+        val meetingPlace = getMeetingPlaces()
 
         return BottlePingPongResponse(
             isStopped = bottle.pingPongStatus == PingPongStatus.STOPPED,
@@ -231,7 +233,9 @@ class BottleFacade(
                 matchStatus = getMatchedStatus(myLetter = myLetter, otherLetter = otherLetter, bottle = bottle),
                 otherContact = otherUser.kakaoId ?: throw IllegalArgumentException("고객센터에 문의 주세요"),
                 shouldAnswer = myLetter.isShareContact == null,
-                isFirstSelect = bottle.firstSelectUser == me
+                isFirstSelect = bottle.firstSelectUser == me,
+                meetingPlace = meetingPlace.key,
+                meetingPlaceImageUrl = meetingPlace.value,
             )
         )
     }
@@ -303,6 +307,15 @@ class BottleFacade(
             bottle.pingPongStatus == PingPongStatus.MATCHED -> MatchStatusType.MATCH_SUCCEEDED
             else -> MatchStatusType.NONE
         }
+    }
+
+    private fun getMeetingPlaces(): Map.Entry<String, String> {
+        val places = mapOf(
+            "남산타워" to "https://bottles-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%82%E1%85%A1%E1%86%B7%E1%84%89%E1%85%A1%E1%86%AB%E1%84%90%E1%85%A1%E1%84%8B%E1%85%AF.png",
+            "청계천" to "https://bottles-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%8E%E1%85%A5%E1%86%BC%E1%84%80%E1%85%A8%E1%84%8E%E1%85%A5%E1%86%AB.png",
+            "북촌한옥마을" to "https://bottles-bucket.s3.ap-northeast-2.amazonaws.com/%E1%84%92%E1%85%A1%E1%86%AB%E1%84%8B%E1%85%A9%E1%86%A8%E1%84%86%E1%85%A1%E1%84%8B%E1%85%B3%E1%86%AF.png"
+        )
+        return places.entries.random()
     }
 
     fun selectShareImage(userId: Long, bottleId: Long, willShare: Boolean) {

--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/dto/BottlePingPongResponse.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/dto/BottlePingPongResponse.kt
@@ -62,6 +62,8 @@ data class MatchResult(
     val otherContact: String,
     val shouldAnswer: Boolean,
     val isFirstSelect: Boolean,
+    val meetingPlace: String? = null,
+    val meetingPlaceImageUrl: String? = null,
 )
 
 enum class MatchStatusType {

--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/dto/BottlePingPongResponse.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/dto/BottlePingPongResponse.kt
@@ -65,8 +65,11 @@ data class MatchResult(
 )
 
 enum class MatchStatusType {
-    IN_CONVERSATION, // 대화중
-    MATCH_FAILED, // 매치 실패
-    MATCH_SUCCEEDED, // 매치 성공
+    NONE, // 아직 최종 선택 단계가 아닐 때
+    REQUIRE_SELECT, // 최종 선택을 해야할 때
+    WAITING_OTHER_ANSWER, // 상대의 답변을 기다려야 할 때
+    IN_CONVERSATION, // 대화중일 때
+    MATCH_FAILED, // 매칭 실패 했을 때
+    MATCH_SUCCEEDED, // 매칭 성공 했을 때
     ;
 }


### PR DESCRIPTION
## 💡 이슈 번호
close: #223 

## ✨ 작업 내용
- 핑퐁 조회 API MatchStatus 상태값을 추가했습니다.
- 매치 결과에 장소 추가했습니다.

## 🚀 전달 사항
```
enum class MatchStatus {
    NONE, // 아직 최종 선택 단계가 아닐 때
    REQUIRE_SELECT, // 최종 선택을 해야할 때
    WAITING_OTHER_ANSWER, // 상대의 답변을 기다려야 할 때
    IN_CONVERSATION, // 대화중일 때
    MATCH_FAILED, // 매칭 실패 했을 때
    MATCH_SUCCEEDED, // 매칭 성공 했을 때
    ;
}
```