### PR TITLE
[Feature/225] 보틀 수락 및 어드민 API에 cache evict 추가한다

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacade.kt
@@ -134,6 +134,7 @@ class BottleFacade(
         )
     }
 
+    @CacheEvict(PING_PONG_BOTTLE_LIST, key = "#userId")
     fun acceptBottle(userId: Long, bottleId: Long, acceptBottleRequest: AcceptBottleRequest) {
         val allQuestions = questionCachingService.findAllQuestions()
         bottleService.acceptBottle(userId, bottleId, acceptBottleRequest.likeMessage, allQuestions)

--- a/app/src/main/kotlin/com/nexters/bottles/app/admin/service/AdminService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/admin/service/AdminService.kt
@@ -7,11 +7,13 @@ import com.nexters.bottles.app.bottle.domain.Bottle
 import com.nexters.bottles.app.bottle.domain.enum.BottleStatus
 import com.nexters.bottles.app.bottle.repository.BottleRepository
 import com.nexters.bottles.app.bottle.repository.LetterRepository
+import com.nexters.bottles.app.config.CacheType.Name.PING_PONG_BOTTLE_LIST
 import com.nexters.bottles.app.user.domain.User
 import com.nexters.bottles.app.user.domain.UserProfile
 import com.nexters.bottles.app.user.repository.UserProfileRepository
 import com.nexters.bottles.app.user.repository.UserRepository
 import org.jetbrains.annotations.TestOnly
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -54,6 +56,7 @@ class AdminService(
 
     @TestOnly
     @Transactional
+    @CacheEvict(PING_PONG_BOTTLE_LIST, key = "#user.id")
     fun cleanUpMockUpData(user: User) {
         userRepository.findByIdOrNull(user.id)?.let { user ->
             letterRepository.findAllByUserId(user.id).forEach {


### PR DESCRIPTION
## 💡 이슈 번호
close: #225 

## ✨ 작업 내용
- 보틀 수락 및 어드민 API에 cache evict 추가했습니다.

## 🚀 전달 사항
