### PR TITLE
[Feature/233] 회원 탈퇴 시 핑퐁 중이던 대화를 멈추도록 한다

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/component/AuthApplicationEventListener.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/component/AuthApplicationEventListener.kt
@@ -1,0 +1,24 @@
+package com.nexters.bottles.api.auth.component
+
+import com.nexters.bottles.api.auth.component.event.DeleteUserEventDto
+import com.nexters.bottles.app.bottle.service.BottleCachingService
+import com.nexters.bottles.app.bottle.service.BottleService
+import org.springframework.context.event.EventListener
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+
+@Component
+class AuthApplicationEventListener(
+    private val bottleService: BottleService,
+    private val bottleCachingService: BottleCachingService
+) {
+
+    @Async
+    @EventListener
+    fun handleCustomEvent(event: DeleteUserEventDto) {
+        val pingPongBottles = bottleService.getPingPongBottles(event.userId)
+        pingPongBottles.forEach {
+            bottleCachingService.stop(userId = event.userId, bottleId = it.id)
+        }
+    }
+}

--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/component/AuthApplicationEventListener.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/component/AuthApplicationEventListener.kt
@@ -18,7 +18,8 @@ class AuthApplicationEventListener(
     fun handleCustomEvent(event: DeleteUserEventDto) {
         val pingPongBottles = bottleService.getPingPongBottles(event.userId)
         pingPongBottles.forEach {
-            bottleCachingService.stop(userId = event.userId, bottleId = it.id)
+            val stoppedBottle = bottleService.stop(userId = event.userId, bottleId = it.id)
+            bottleCachingService.evictPingPongList(stoppedBottle.sourceUser.id, stoppedBottle.targetUser.id)
         }
     }
 }

--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/component/event/DeleteUserEventDto.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/component/event/DeleteUserEventDto.kt
@@ -1,0 +1,5 @@
+package com.nexters.bottles.api.auth.component.event
+
+data class DeleteUserEventDto(
+    val userId: Long
+)

--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/facade/AuthFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/facade/AuthFacade.kt
@@ -3,6 +3,7 @@ package com.nexters.bottles.api.auth.facade
 import com.nexters.bottles.api.auth.component.AuthCodeGenerator
 import com.nexters.bottles.api.auth.component.JwtTokenProvider
 import com.nexters.bottles.api.auth.component.NaverSmsEncoder
+import com.nexters.bottles.api.auth.component.event.DeleteUserEventDto
 import com.nexters.bottles.api.auth.facade.dto.AuthSmsRequest
 import com.nexters.bottles.api.auth.facade.dto.KakaoSignInUpResponse
 import com.nexters.bottles.api.auth.facade.dto.MessageDto
@@ -21,6 +22,7 @@ import com.nexters.bottles.app.user.service.dto.KakaoUserInfoResponse
 import com.nexters.bottles.app.user.service.dto.SignUpRequest
 import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -36,6 +38,7 @@ class AuthFacade(
     private val jwtTokenProvider: JwtTokenProvider,
     private val naverSmsEncoder: NaverSmsEncoder,
     private val authCodeGenerator: AuthCodeGenerator,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 
     @Value("\${super-user-number}")
     private val superUserNumber: String,
@@ -118,6 +121,7 @@ class AuthFacade(
 
     fun delete(userId: Long) {
         userService.softDelete(userId)
+        applicationEventPublisher.publishEvent(DeleteUserEventDto(userId = userId))
     }
 
     fun smsSignIn(smsSignInRequest: SmsSignInRequest): SmsSignInResponse {

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleCachingService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleCachingService.kt
@@ -3,7 +3,9 @@ package com.nexters.bottles.app.bottle.service
 import com.nexters.bottles.app.bottle.domain.Bottle
 import com.nexters.bottles.app.config.CacheType.Name.PING_PONG_BOTTLE
 import com.nexters.bottles.app.config.CacheType.Name.PING_PONG_BOTTLE_LIST
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.Cacheable
+import org.springframework.cache.annotation.Caching
 import org.springframework.stereotype.Service
 
 @Service
@@ -19,5 +21,15 @@ class BottleCachingService(
     @Cacheable(PING_PONG_BOTTLE_LIST, key = "#userId")
     fun getPingPongBottles(userId: Long): List<Bottle> {
         return bottleService.getPingPongBottles(userId)
+    }
+
+    @Caching(
+        evict = [
+            CacheEvict(PING_PONG_BOTTLE_LIST, key = "#userId"),
+            CacheEvict(PING_PONG_BOTTLE, key = "#bottleId")
+        ]
+    )
+    fun stop(userId: Long, bottleId: Long) {
+        bottleService.stop(userId, bottleId)
     }
 }

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleCachingService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleCachingService.kt
@@ -25,11 +25,10 @@ class BottleCachingService(
 
     @Caching(
         evict = [
-            CacheEvict(PING_PONG_BOTTLE_LIST, key = "#userId"),
-            CacheEvict(PING_PONG_BOTTLE, key = "#bottleId")
+            CacheEvict(PING_PONG_BOTTLE_LIST, key = "#sourceUserId"),
+            CacheEvict(PING_PONG_BOTTLE_LIST, key = "#targetUserId")
         ]
     )
-    fun stop(userId: Long, bottleId: Long) {
-        bottleService.stop(userId, bottleId)
+    fun evictPingPongList(sourceUserId: Long, targetUserId: Long) {
     }
 }

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleService.kt
@@ -116,7 +116,7 @@ class BottleService(
     }
 
     @Transactional
-    fun stop(userId: Long, bottleId: Long) {
+    fun stop(userId: Long, bottleId: Long): Bottle {
         val bottle = bottleRepository.findByIdAndStatusAndDeletedFalse(
             bottleId,
             setOf(
@@ -129,6 +129,7 @@ class BottleService(
             userRepository.findByIdAndDeletedFalse(userId) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
 
         bottle.stop(stoppedUser, LocalDateTime.now())
+        return bottle
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 💡 이슈 번호
close: #233 

## ✨ 작업 내용
- 회원 탈퇴 시 핑퐁 중이던 대화를 멈추도록 했습니다.

## 🚀 전달 사항
- 핑퐁 데이터가 변경될 때 sourceUser, targetUser의 캐싱된 PingPongBottleList를 모두 지워야해서 기존에 facade에서 evict 하던 것을 cacingService에서 하도록 구조를 변경했는데 괜찮은지 모르겠어요. 어떻게 하는게 좋을까요?