### PR TITLE
[Fix/251] 보틀 수락 시 보틀 목록 cache evict 한다

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacade.kt
@@ -136,7 +136,13 @@ class BottleFacade(
     @CacheEvict(PING_PONG_BOTTLE_LIST, key = "#userId")
     fun acceptBottle(userId: Long, bottleId: Long, acceptBottleRequest: AcceptBottleRequest) {
         val allQuestions = questionCachingService.findAllQuestions()
-        bottleService.acceptBottle(userId, bottleId, acceptBottleRequest.likeMessage, allQuestions)
+        val acceptBottle = bottleService.acceptBottle(userId, bottleId, acceptBottleRequest.likeMessage, allQuestions)
+        if (acceptBottle.isActive()) {
+            bottleCachingService.evictPingPongList(
+                sourceUserId = acceptBottle.sourceUser.id,
+                targetUserId = acceptBottle.targetUser.id
+            )
+        }
     }
 
     fun refuseBottle(userId: Long, bottleId: Long) {

--- a/app/src/main/kotlin/com/nexters/bottles/app/admin/service/AdminService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/admin/service/AdminService.kt
@@ -7,13 +7,11 @@ import com.nexters.bottles.app.bottle.domain.Bottle
 import com.nexters.bottles.app.bottle.domain.enum.BottleStatus
 import com.nexters.bottles.app.bottle.repository.BottleRepository
 import com.nexters.bottles.app.bottle.repository.LetterRepository
-import com.nexters.bottles.app.config.CacheType.Name.PING_PONG_BOTTLE_LIST
 import com.nexters.bottles.app.user.domain.User
 import com.nexters.bottles.app.user.domain.UserProfile
 import com.nexters.bottles.app.user.repository.UserProfileRepository
 import com.nexters.bottles.app.user.repository.UserRepository
 import org.jetbrains.annotations.TestOnly
-import org.springframework.cache.annotation.CacheEvict
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -56,7 +54,6 @@ class AdminService(
 
     @TestOnly
     @Transactional
-    @CacheEvict(PING_PONG_BOTTLE_LIST, key = "#user.id")
     fun cleanUpMockUpData(user: User) {
         userRepository.findByIdOrNull(user.id)?.let { user ->
             letterRepository.findAllByUserId(user.id).forEach {

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/domain/Bottle.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/domain/Bottle.kt
@@ -110,6 +110,10 @@ class Bottle(
         return pingPongStatus == PingPongStatus.STOPPED
     }
 
+    fun isActive(): Boolean {
+        return pingPongStatus == PingPongStatus.ACTIVE
+    }
+
     fun calculateDeletedAfterDays(): Long? {
         if (stoppedAt == null) return null
 

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleService.kt
@@ -47,7 +47,7 @@ class BottleService(
     }
 
     @Transactional
-    fun acceptBottle(userId: Long, bottleId: Long, likeMessage: String?, questions: List<Question>) {
+    fun acceptBottle(userId: Long, bottleId: Long, likeMessage: String?, questions: List<Question>): Bottle {
         val bottle =
             bottleRepository.findByIdAndStatusAndNotExpiredAndDeletedFalse(
                 bottleId,
@@ -80,6 +80,7 @@ class BottleService(
                 saveLetter(bottle, sourceUser, letters)
             }
         }
+        return bottle
     }
 
     private fun findRandomQuestions(questions: List<Question>) = questions


### PR DESCRIPTION
## 💡 이슈 번호
close: #251 

## ✨ 작업 내용
- 보틀 수락 시 보틀 목록 cache evict 했습니다.
- admin clean up 할 때 테스트 계정의 보틀 목록 cache evict 했습니다.

## 🚀 전달 사항
