### PR TITLE
[Fix/253] 로그아웃 시 fcm 토큰 request body null을 허용한다

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/controller/AuthController.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/controller/AuthController.kt
@@ -69,7 +69,7 @@ class AuthController(
     @ApiOperation("로그아웃하기")
     @PostMapping("/logout")
     @AuthRequired
-    fun logout(@AuthUserId userId: Long, @AccessToken accessToken: String, @RequestBody logoutRequest: LogoutRequest) {
+    fun logout(@AuthUserId userId: Long, @AccessToken accessToken: String, @RequestBody logoutRequest: LogoutRequest?) {
         authFacade.logout(userId, accessToken, logoutRequest)
     }
 

--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/facade/AuthFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/facade/AuthFacade.kt
@@ -124,10 +124,10 @@ class AuthFacade(
         lastAuthSms.validate(lastAuthSms.authCode)
     }
 
-    fun logout(userId: Long, accessToken: String, logoutRequest: LogoutRequest) {
+    fun logout(userId: Long, accessToken: String, logoutRequest: LogoutRequest?) {
         blackListService.add(accessToken)
         refreshTokenService.delete(userId)
-        logoutRequest.fcmDeviceToken?.let {
+        logoutRequest?.fcmDeviceToken?.let {
             fcmTokenService.deleteFcmToken(userId, logoutRequest.fcmDeviceToken)
         }
     }


### PR DESCRIPTION
## 💡 이슈 번호
close: #253 

## ✨ 작업 내용
- 이전 버전과의 호환성을 위해 로그아웃 시 fcm 토큰 request body null을 허용했습니다.

## 🚀 전달 사항
