### PR TITLE
[Fix/264] 보틀 조회 시 user deleted 여부 확인 및 자기소개 없으면 매칭되지 않도록 수정한다

### DIFF
--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/repository/BottleRepository.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/repository/BottleRepository.kt
@@ -14,9 +14,8 @@ interface BottleRepository : JpaRepository<Bottle, Long> {
 
     @Query(
         value = "SELECT b FROM Bottle b " +
-                "JOIN FETCH b.sourceUser " +
                 "WHERE b.targetUser = :targetUser AND b.expiredAt > :currentDateTime AND b.pingPongStatus = :pingPongStatus " +
-                "AND b.deleted = false "
+                "AND b.deleted = false AND b.targetUser.deleted = false AND b.sourceUser.deleted = false "
     )
     fun findAllByTargetUserAndStatusAndNotExpiredAndDeletedFalse(
         @Param("targetUser") targetUser: User,
@@ -26,9 +25,8 @@ interface BottleRepository : JpaRepository<Bottle, Long> {
 
     @Query(
         value = "SELECT b FROM Bottle b " +
-                "JOIN FETCH b.sourceUser " +
                 "WHERE b.id = :bottleId AND b.expiredAt > :currentDateTime AND b.pingPongStatus IN :pingPongStatus " +
-                "AND b.deleted = false "
+                "AND b.deleted = false AND b.targetUser.deleted = false AND b.sourceUser.deleted = false "
     )
     fun findByIdAndStatusAndNotExpiredAndDeletedFalse(
         @Param("bottleId") bottleId: Long,
@@ -38,7 +36,8 @@ interface BottleRepository : JpaRepository<Bottle, Long> {
 
     @Query(
         value = "SELECT b FROM Bottle b " +
-                "WHERE (b.targetUser = :user OR b.sourceUser = :user) " +
+                "WHERE (b.targetUser = :user AND b.targetUser.deleted = false) " +
+                "OR (b.sourceUser = :user AND b.sourceUser.deleted = false ) " +
                 "AND b.pingPongStatus IN :pingPongStatus " +
                 "AND b.deleted = false "
     )
@@ -49,7 +48,8 @@ interface BottleRepository : JpaRepository<Bottle, Long> {
 
     @Query(
         value = "SELECT b FROM Bottle b " +
-                "WHERE b.id = :bottleId AND b.pingPongStatus IN :pingPongStatus AND b.deleted = false "
+                "WHERE b.id = :bottleId AND b.pingPongStatus IN :pingPongStatus AND b.deleted = false " +
+                "AND b.targetUser.deleted = false AND b.sourceUser.deleted = false "
     )
     fun findByIdAndStatusAndDeletedFalse(
         @Param("bottleId") bottleId: Long,

--- a/app/src/main/kotlin/com/nexters/bottles/app/user/domain/User.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/user/domain/User.kt
@@ -66,4 +66,8 @@ class User(
     fun isMatchInactive(): Boolean {
         return !isMatchActivated
     }
+
+    fun isNotRegisterProfile(): Boolean {
+        return userProfile?.isNotRegisterIntroductionOrImage() ?: false
+    }
 }

--- a/app/src/main/kotlin/com/nexters/bottles/app/user/domain/User.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/user/domain/User.kt
@@ -68,6 +68,6 @@ class User(
     }
 
     fun isNotRegisterProfile(): Boolean {
-        return userProfile?.isNotRegisterIntroductionOrImage() ?: false
+        return userProfile?.isNotRegisterIntroductionOrImage() ?: true
     }
 }

--- a/app/src/main/kotlin/com/nexters/bottles/app/user/domain/UserProfile.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/user/domain/UserProfile.kt
@@ -36,6 +36,10 @@ class UserProfile(
     fun hasCompleteIntroduction(): Boolean {
         return introduction.isNotEmpty()
     }
+
+    fun isNotRegisterIntroductionOrImage(): Boolean {
+        return introduction.isEmpty() || imageUrl == null
+    }
 }
 
 data class UserProfileSelect(


### PR DESCRIPTION
## 💡 이슈 번호
close: #264 

## ✨ 작업 내용
- 보틀 조회 시 user deleted 여부 확인하도록 했습니다.
- 자기소개와 이미지가 없으면 랜덤 매칭을 하지 않도록 했습니다.

## 🚀 전달 사항
