### PR TITLE
[Feature/273] 유저 정보 조회 API에 애플 로그인만 한 상태를 추가한다

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/controller/AuthControllerV2.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/controller/AuthControllerV2.kt
@@ -1,7 +1,6 @@
 package com.nexters.bottles.api.auth.controller
 
 import com.nexters.bottles.api.auth.facade.AuthFacade
-import com.nexters.bottles.api.auth.facade.dto.SignUpResponse
 import com.nexters.bottles.api.auth.facade.dto.SignUpResponseV2
 import com.nexters.bottles.api.global.interceptor.AuthRequired
 import com.nexters.bottles.api.global.resolver.AuthUserId
@@ -25,7 +24,7 @@ class AuthControllerV2(
         return authFacade.smsSignUpV2(signUpRequestV2)
     }
 
-    @ApiOperation("일반 회원가입하기 v2 -  생년월일 / 성별 /이름 입력")
+    @ApiOperation("일반 회원가입하기 v2 -  생년월일 / 성별 / 이름 입력")
     @PostMapping("/profile")
     @AuthRequired
     fun signUpProfile(@AuthUserId userId: Long, @RequestBody signUpProfileRequestV2: SignUpProfileRequestV2) {

--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/facade/AuthFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/facade/AuthFacade.kt
@@ -247,7 +247,8 @@ class AuthFacade(
         userService.signUpProfile(
             userId,
             signUpProfileRequestV2.name,
-            signUpProfileRequestV2.convertBirthDateToLocalDate()
+            signUpProfileRequestV2.convertBirthDateToLocalDate(),
+            signUpProfileRequestV2.gender
         )
     }
 

--- a/api/src/main/kotlin/com/nexters/bottles/api/user/facade/UserProfileFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/user/facade/UserProfileFacade.kt
@@ -9,6 +9,7 @@ import com.nexters.bottles.api.user.facade.dto.UserProfileResponse
 import com.nexters.bottles.api.user.facade.dto.UserProfileStatus
 import com.nexters.bottles.api.user.facade.dto.UserProfileStatusResponse
 import com.nexters.bottles.app.common.component.ImageUploader
+import com.nexters.bottles.app.user.domain.User
 import com.nexters.bottles.app.user.domain.UserProfile
 import com.nexters.bottles.app.user.domain.UserProfileSelect
 import com.nexters.bottles.app.user.service.UserProfileService
@@ -136,12 +137,12 @@ class UserProfileFacade(
 
     fun findUserInfo(userId: Long): UserInfoResponse {
         val user = userService.findByIdAndNotDeleted(userId)
-        return UserInfoResponse(name = user.name, signInUpStep = getSignInUpStep(user.name))
+        return UserInfoResponse(name = user.name, signInUpStep = getSignInUpStep(user))
     }
 
-    private fun getSignInUpStep(name: String?): SignInUpStep {
-        return if (name == "보틀") {
-            SignInUpStep.SIGN_UP_SMS_FINISHED
+    private fun getSignInUpStep(user: User): SignInUpStep {
+        return if (user.name == null || user.birthdate == null || user.gender == null) {
+            SignInUpStep.SIGN_UP_APPLE_LOGIN_FINISHED
         } else {
             SignInUpStep.SIGN_UP_NAME_GENDER_AGE_FINISHED
         }

--- a/app/src/main/kotlin/com/nexters/bottles/app/user/service/UserService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/user/service/UserService.kt
@@ -140,10 +140,11 @@ class UserService(
     }
 
     @Transactional
-    fun signUpProfile(userId: Long, name: String, birthDate: LocalDate) {
+    fun signUpProfile(userId: Long, name: String, birthDate: LocalDate, gender: Gender) {
         userRepository.findByIdOrNull(userId)?.let { user ->
             user.name = name
             user.birthdate = birthDate
+            user.gender = gender
         } ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
     }
 

--- a/app/src/main/kotlin/com/nexters/bottles/app/user/service/dto/SignInUpStep.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/user/service/dto/SignInUpStep.kt
@@ -1,8 +1,7 @@
 package com.nexters.bottles.app.user.service.dto
 
 enum class SignInUpStep {
-    SIGN_IN,                             // 로그인
-    SIGN_UP_SMS_FINISHED,                // 회원가입만 한 상태
-    SIGN_UP_NAME_GENDER_AGE_FINISHED,    // 회원 가입후 이름,성별, 나이 입력한 상태
+    SIGN_UP_APPLE_LOGIN_FINISHED,        // 애플 로그인만 한 상태
+    SIGN_UP_NAME_GENDER_AGE_FINISHED,    // 애플 로그인 후 이름, 성별, 나이 입력한 상태
     ;
 }


### PR DESCRIPTION
## 💡 이슈 번호
close: #273 

## ✨ 작업 내용
- 애플 로그인만 한 상태로 변경했습니다. (SIGN_UP_SMS_FINISHED  -> SIGN_UP_APPLE_LOGIN_FINISHED)

## 🚀 전달 사항
