### PR TITLE
[Feature/275] 애플 로그인 탈퇴를 위한 client secret 값 조회 API를 구현한다

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/controller/AuthController.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/controller/AuthController.kt
@@ -1,6 +1,7 @@
 package com.nexters.bottles.api.auth.controller
 
 import com.nexters.bottles.api.auth.facade.AuthFacade
+import com.nexters.bottles.api.auth.facade.dto.AppleRevokeResponse
 import com.nexters.bottles.api.auth.facade.dto.AppleSignInUpRequest
 import com.nexters.bottles.api.auth.facade.dto.AppleSignInUpResponse
 import com.nexters.bottles.api.auth.facade.dto.AuthSmsRequest
@@ -20,6 +21,7 @@ import com.nexters.bottles.api.global.resolver.AuthUserId
 import com.nexters.bottles.api.global.resolver.RefreshTokenUserId
 import com.nexters.bottles.app.user.service.dto.SignUpRequest
 import io.swagger.annotations.ApiOperation
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -86,5 +88,12 @@ class AuthController(
     @AuthRequired
     fun delete(@AuthUserId userId: Long) {
         authFacade.delete(userId)
+    }
+
+    @ApiOperation("애플 로그인 탈퇴를 위한 client secret 값 조회하기")
+    @GetMapping("/apple/revoke")
+    @AuthRequired
+    fun getAppleClientSecret(): AppleRevokeResponse {
+        return authFacade.getAppleClientSecret()
     }
 }

--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/facade/AuthFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/facade/AuthFacade.kt
@@ -1,10 +1,12 @@
 package com.nexters.bottles.api.auth.facade
 
+import com.nexters.bottles.api.auth.component.AppleAuthClientSecretKeyGenerator
 import com.nexters.bottles.api.auth.component.AuthCodeGenerator
 import com.nexters.bottles.api.auth.component.JwtTokenProvider
 import com.nexters.bottles.api.auth.component.NaverSmsEncoder
 import com.nexters.bottles.api.auth.component.event.DeleteUserEventDto
 import com.nexters.bottles.api.auth.facade.dto.AppleIdTokenPayload
+import com.nexters.bottles.api.auth.facade.dto.AppleRevokeResponse
 import com.nexters.bottles.api.auth.facade.dto.AppleSignInUpRequest
 import com.nexters.bottles.api.auth.facade.dto.AppleSignInUpResponse
 import com.nexters.bottles.api.auth.facade.dto.AuthSmsRequest
@@ -48,6 +50,7 @@ class AuthFacade(
     private val jwtTokenProvider: JwtTokenProvider,
     private val naverSmsEncoder: NaverSmsEncoder,
     private val authCodeGenerator: AuthCodeGenerator,
+    private val appleAuthClientSecretKeyGenerator: AppleAuthClientSecretKeyGenerator,
     private val applicationEventPublisher: ApplicationEventPublisher,
 
     @Value("\${super-user-number}")
@@ -250,6 +253,11 @@ class AuthFacade(
             signUpProfileRequestV2.convertBirthDateToLocalDate(),
             signUpProfileRequestV2.gender
         )
+    }
+
+    fun getAppleClientSecret(): AppleRevokeResponse {
+        val clientSecret = appleAuthClientSecretKeyGenerator.generate()
+        return AppleRevokeResponse(clientSecret = clientSecret)
     }
 
     private fun isSuperUser(phoneNumber: String) = phoneNumber == superUserNumber

--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/facade/dto/AppleRevokeResponse.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/facade/dto/AppleRevokeResponse.kt
@@ -1,0 +1,7 @@
+package com.nexters.bottles.api.auth.facade.dto
+
+data class AppleRevokeResponse(
+    val clientSecret: String,
+) {
+
+}


### PR DESCRIPTION
## 💡 이슈 번호
close: #275 

## ✨ 작업 내용
- 애플 로그인 탈퇴를 위한 client secret 값 조회 API를 구현했습니다.

## 🚀 전달 사항
