### PR TITLE
[Feature/285] 로컬에서 dns를 못찾는 예외 로그 제거 / 애플 ClientSecret 유효시간 늘리기

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/component/AppleAuthClientSecretKeyGenerator.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/component/AppleAuthClientSecretKeyGenerator.kt
@@ -51,7 +51,7 @@ class AppleAuthClientSecretKeyGenerator(
         val privateKey = jcaPEMKeyConverter.getPrivateKey(privateKeyInfo)
 
         val now = LocalDateTime.now()
-        val expiryDate = now.plus(Duration.ofMillis(1000 * 120))
+        val expiryDate = now.plus(Duration.ofMillis(EXPIRATION_MILLIS))
         return Jwts
             .builder()
             .setHeaderParam(JwsHeader.KEY_ID, appleKeyId)
@@ -62,6 +62,10 @@ class AppleAuthClientSecretKeyGenerator(
             .setExpiration(toDate(expiryDate))
             .signWith(privateKey, SignatureAlgorithm.ES256)
             .compact()
+    }
+
+    companion object {
+        const val EXPIRATION_MILLIS = (1000 * 60 * 6).toLong() // 6시간
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,6 +20,16 @@ dependencies {
 
     runtimeOnly("com.h2database:h2")
     runtimeOnly("mysql:mysql-connector-java")
+
+    val isMacOS: Boolean = System.getProperty("os.name").startsWith("Mac OS X")
+    val architecture = System.getProperty("os.arch").toLowerCase()
+    if (isMacOS && architecture == "aarch64")  {
+        implementation("io.netty:netty-resolver-dns-native-macos:4.1.75.Final") {
+            artifact {
+                classifier = "osx-aarch_64"
+            }
+        }
+    }
 }
 
 tasks.named("jar") {


### PR DESCRIPTION
## 💡 이슈 번호
close: #285 

## ✨ 작업 내용
- 로컬에서 dns를 못찾는 예외 로그 제거
- 애플 ClientSecret 유효시간 늘리기

## 🚀 전달 사항
이거 netty 이슈라고 올라오는거 실제로 예외는 아니지만 노이지 할 수 있어 올립니다. 맥북에서만 발생하는걸로 알고 있어요!