### PR TITLE
[Fix/296] 회원 탈퇴 시 보틀 중단하는 메서드를 수정한다

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/component/AuthApplicationEventListener.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/component/AuthApplicationEventListener.kt
@@ -25,9 +25,9 @@ class AuthApplicationEventListener(
         blackListService.add(event.accessToken)
         refreshTokenService.delete(event.userId)
 
-        val pingPongBottles = bottleService.getPingPongBottles(event.userId)
+        val pingPongBottles = bottleService.getPingPongBottlesByDeletedUser(event.userId)
         pingPongBottles.forEach {
-            val stoppedBottle = bottleService.stop(userId = event.userId, bottleId = it.id)
+            val stoppedBottle = bottleService.stopByDeletedUser(userId = event.userId, bottle = it)
             bottleCachingService.evictPingPongList(stoppedBottle.sourceUser.id, stoppedBottle.targetUser.id)
         }
 

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/repository/BottleRepository.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/repository/BottleRepository.kt
@@ -41,6 +41,17 @@ interface BottleRepository : JpaRepository<Bottle, Long> {
                 "AND b.pingPongStatus IN :pingPongStatus " +
                 "AND b.deleted = false "
     )
+    fun findAllByNotDeletedUserAndStatusAndDeletedFalse(
+        @Param("user") user: User,
+        @Param("pingPongStatus") pingPongStatus: Set<PingPongStatus>
+    ): List<Bottle>
+
+    @Query(
+        value = "SELECT b FROM Bottle b " +
+                "WHERE b.targetUser = :user OR b.sourceUser = :user " +
+                "AND b.pingPongStatus IN :pingPongStatus " +
+                "AND b.deleted = false "
+    )
     fun findAllByUserAndStatusAndDeletedFalse(
         @Param("user") user: User,
         @Param("pingPongStatus") pingPongStatus: Set<PingPongStatus>


### PR DESCRIPTION
## 💡 이슈 번호
close: #296 

## ✨ 작업 내용
- 회원 탈퇴 시 보틀을 중단하는 메서드를 수정했습니다.

## 🚀 전달 사항
- 기존 `bottleService.getPingPongBottles` 메서드에서 보틀을 조회할 때 deleted = false인 user만 조회를 해서, 탈퇴 후 보틀을 중단하려고 할 때 보틀이 조회되지 않는 문제가 있었습니다.