### PR TITLE
feat: 애플 로그인시 나이/성별을 필수로 받지않고, 애플로그인 유저면 유저이름 정보 조회시 응답 상태값을 변경한다

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/facade/AuthFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/facade/AuthFacade.kt
@@ -273,7 +273,7 @@ class AuthFacade(
             userId,
             signUpProfileRequestV2.name,
             signUpProfileRequestV2.convertBirthDateToLocalDate(),
-            signUpProfileRequestV2.gender
+            signUpProfileRequestV2.gender!!,
         )
     }
 

--- a/api/src/main/kotlin/com/nexters/bottles/api/user/controller/UserProfileController.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/user/controller/UserProfileController.kt
@@ -68,7 +68,7 @@ class UserProfileController(
         return profileFacade.existIntroduction(userId)
     }
 
-    @ApiOperation("유저 이름 (정보 조회)")
+    @ApiOperation("유저 이름 및 가입 상태 조회")
     @GetMapping("/info")
     @AuthRequired
     fun findInfo(@AuthUserId userId: Long): UserInfoResponse {

--- a/api/src/main/kotlin/com/nexters/bottles/api/user/facade/UserProfileFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/user/facade/UserProfileFacade.kt
@@ -15,6 +15,7 @@ import com.nexters.bottles.app.user.domain.UserProfileSelect
 import com.nexters.bottles.app.user.service.UserProfileService
 import com.nexters.bottles.app.user.service.UserService
 import com.nexters.bottles.app.user.service.dto.SignInUpStep
+import com.nexters.bottles.app.user.service.dto.SignInUpStep.*
 import mu.KotlinLogging
 import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
@@ -140,11 +141,18 @@ class UserProfileFacade(
         return UserInfoResponse(name = user.name, signInUpStep = getSignInUpStep(user))
     }
 
+    /**
+     * 애플 로그인으로 가입하는 경우 성별/나이를 입력 받지 못해 서버에서 '오늘' 날짜를 입력해줍니다.
+     * 성별/나이를 입력받지 않아도 화면상으로 다 입력 받은 다음 단계로 가야하기 때문에 2024년 출생으로
+     * 되어있으면 이름/성별/나이를 입력했다고 내려줍니다.
+     */
     private fun getSignInUpStep(user: User): SignInUpStep {
-        return if (user.name == null || user.birthdate == null || user.gender == null) {
-            SignInUpStep.SIGN_UP_APPLE_LOGIN_FINISHED
+        return if (user.birthdate?.year == 2024) {
+            SIGN_UP_NAME_GENDER_AGE_FINISHED
+        } else if (user.name == null || user.birthdate == null || user.gender == null) {
+            SIGN_UP_APPLE_LOGIN_FINISHED
         } else {
-            SignInUpStep.SIGN_UP_NAME_GENDER_AGE_FINISHED
+            SIGN_UP_NAME_GENDER_AGE_FINISHED
         }
     }
 

--- a/app/src/main/kotlin/com/nexters/bottles/app/user/service/dto/SignUpProfileRequestV2.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/user/service/dto/SignUpProfileRequestV2.kt
@@ -5,13 +5,13 @@ import java.time.LocalDate
 
 data class SignUpProfileRequestV2(
     val name: String,
-    val birthYear: Int,
-    val birthMonth: Int,
-    val birthDay: Int,
-    val gender: Gender,
+    val birthYear: Int? = LocalDate.now().year,
+    val birthMonth: Int? = LocalDate.now().monthValue,
+    val birthDay: Int? = LocalDate.now().dayOfMonth,
+    val gender: Gender? = Gender.FEMALE,
 ) {
 
     fun convertBirthDateToLocalDate(): LocalDate {
-        return LocalDate.of(birthYear, birthMonth, birthDay)
+        return LocalDate.of(birthYear!!, birthMonth!!, birthDay!!)
     }
 }


### PR DESCRIPTION
## 💡 이슈 번호
close: #298 

## ✨ 작업 내용
애플 로그인시 나이/성별을 필수로 받지않고, 애플로그인 유저면 유저이름 정보 조회시 응답 상태값을 변경한다

## 🚀 전달 사항
