### PR TITLE
[Fix/311] 유저 프로필 상태 조회 api 수정

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/user/facade/UserProfileFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/user/facade/UserProfileFacade.kt
@@ -167,10 +167,10 @@ class UserProfileFacade(
 
     private fun getUserProfileStatus(userProfile: UserProfile?): UserProfileStatus {
         return when {
-            userProfile == null -> UserProfileStatus.EMPTY
-            userProfile.introduction.isNotEmpty() -> UserProfileStatus.INTRODUCE_DONE
-            userProfile.imageUrl != null -> UserProfileStatus.PHOTO_DONE
-            else -> UserProfileStatus.ONLY_PROFILE_CREATED
+            userProfile?.imageUrl != null -> UserProfileStatus.PHOTO_DONE
+            !userProfile?.introduction.isNullOrEmpty() -> UserProfileStatus.INTRODUCE_DONE
+            userProfile != null -> UserProfileStatus.ONLY_PROFILE_CREATED
+            else -> UserProfileStatus.EMPTY
         }
     }
 


### PR DESCRIPTION
## 💡 이슈 번호
close: #311 

## ✨ 작업 내용
EMPTY -> ONLY_PROFILE_CREATED -> INTRODUCE_DONE -> PHOTO_DONE
으로 점점 데이터가 추가되는데 이런 경우 검사는 역순으로 해야하네요. 자기소개도 작성하고 사진도 등록한 사람이 INTRODUCE_DONE에서 걸리는 버그가 있어서 수정합니다

## 🚀 전달 사항
