### PR TITLE
[Feature/319] nginx 컨테이너 실행중이라면 다시 실행되지 않도록 한다

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -26,18 +26,22 @@ fi
 
 sleep 20
 
-if docker-compose ps $AFTER_RUNNING_CONTAINER | grep -q "Up"; then
+RUNNING_NGINX=$(sudo docker ps --filter "name=nginx" --filter "status=running" -q)
+if [ -z "$RUNNING_NGINX" ]; then
   docker-compose up -d nginx
+fi
+
+if docker-compose ps $AFTER_RUNNING_CONTAINER | grep -q "Up"; then
   sed '' /etc/nginx/conf.d/$AFTER_RUNNING_CONTAINER > /etc/nginx/conf.d/${SERVER_NGINX_CONF}
   sudo docker exec nginx nginx -s reload
-
   echo "Nginx 설정을 변경했습니다."
 
   sleep 10
 
+  echo "$BEFORE_RUNNING_CONTAINER 를 중단합니다."
   docker-compose stop $BEFORE_RUNNING_CONTAINER
 else
-  echo "Spring 컨테이너가 실행 중이 아닙니다. Nginx 설정을 변경하지 않습니다."
+  echo "$AFTER_RUNNING_CONTAINER 가 실행 중이 아닙니다. Nginx 설정을 변경하지 않습니다."
 fi
 
 # 중단된 컨테이너가 존재하는지 확인


### PR DESCRIPTION
## 💡 이슈 번호
close: #319 

## ✨ 작업 내용
- 배포 시 nginx 컨테이너가 항상 새로 실행되는 것을 이미 실행중이라면 다시 실행되지 않도록 수정했습니다.

## 🚀 전달 사항
