### PR TITLE
[Fix/335] fcm 토큰 조회 시 빈 값을 제외하여 조회한다

### DIFF
--- a/app/src/main/kotlin/com/nexters/bottles/app/notification/component/FcmNotificationScheduler.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/notification/component/FcmNotificationScheduler.kt
@@ -15,8 +15,8 @@ class FcmNotificationScheduler(
 
     @Scheduled(cron = "0 0 18 * * *")
     fun notifyMatching() {
-        val users = userService.findAllByNotDeleted()
-        val fcmTokens = fcmTokenService.findByUsers(users)
+        val userIds = userService.findAllByNotDeleted().map { it.id }
+        val fcmTokens = fcmTokenService.findAllByUserIds(userIds)
         val tokens = fcmTokens.map { it.token }
 
         val fcmNotification = FcmNotification(

--- a/app/src/main/kotlin/com/nexters/bottles/app/notification/repository/FcmTokenRepository.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/notification/repository/FcmTokenRepository.kt
@@ -2,12 +2,24 @@ package com.nexters.bottles.app.notification.repository
 
 import com.nexters.bottles.app.notification.domain.FcmToken
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface FcmTokenRepository : JpaRepository<FcmToken, Long> {
+
+    @Query(
+        value = "SELECT ft FROM FcmToken ft " +
+                "WHERE ft.token != '' "
+    )
+    fun findAllByUserIdAndTokenNotBlank(userId: Long): List<FcmToken>
 
     fun findAllByUserId(userId: Long): List<FcmToken>
 
     fun findByUserIdAndToken(userId: Long, token: String): FcmToken?
 
-    fun findAllByUserIdIn(userIds: List<Long>): List<FcmToken>
+    @Query(
+        value = "SELECT ft FROM FcmToken ft " +
+                "WHERE ft.token != '' AND ft.userId IN (:userIds)"
+    )
+    fun findAllByUserIdInAndTokenNotBlank(@Param("userIds") userIds: List<Long>): List<FcmToken>
 }

--- a/app/src/main/kotlin/com/nexters/bottles/app/notification/service/FcmTokenService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/notification/service/FcmTokenService.kt
@@ -22,7 +22,7 @@ class FcmTokenService(
     @Transactional(readOnly = true)
     fun findByUsers(users: List<User>): List<FcmToken> {
         return users.flatMap {
-            fcmTokenRepository.findAllByUserId(it.id)
+            fcmTokenRepository.findAllByUserIdAndTokenNotBlank(it.id)
         }
     }
 
@@ -38,11 +38,11 @@ class FcmTokenService(
 
     @Transactional(readOnly = true)
     fun findAllByUserId(userId: Long): List<FcmToken> {
-        return fcmTokenRepository.findAllByUserId(userId)
+        return fcmTokenRepository.findAllByUserIdAndTokenNotBlank(userId)
     }
 
     @Transactional(readOnly = true)
     fun findAllByUserIds(userIds: List<Long>): List<FcmToken> {
-        return fcmTokenRepository.findAllByUserIdIn(userIds)
+        return fcmTokenRepository.findAllByUserIdInAndTokenNotBlank(userIds)
     }
 }

--- a/app/src/main/kotlin/com/nexters/bottles/app/notification/service/FcmTokenService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/notification/service/FcmTokenService.kt
@@ -2,7 +2,6 @@ package com.nexters.bottles.app.notification.service
 
 import com.nexters.bottles.app.notification.domain.FcmToken
 import com.nexters.bottles.app.notification.repository.FcmTokenRepository
-import com.nexters.bottles.app.user.domain.User
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -16,13 +15,6 @@ class FcmTokenService(
         fcmTokenRepository.findByUserIdAndToken(userId, token) ?: run {
             val fcmToken = FcmToken(userId = userId, token = token)
             fcmTokenRepository.save(fcmToken)
-        }
-    }
-
-    @Transactional(readOnly = true)
-    fun findByUsers(users: List<User>): List<FcmToken> {
-        return users.flatMap {
-            fcmTokenRepository.findAllByUserIdAndTokenNotBlank(it.id)
         }
     }
 

--- a/batch/src/main/kotlin/com/nexters/bottles/batch/scheduler/FcmNotificationScheduler.kt
+++ b/batch/src/main/kotlin/com/nexters/bottles/batch/scheduler/FcmNotificationScheduler.kt
@@ -16,8 +16,8 @@ class FcmNotificationScheduler(
 
     @Scheduled(cron = "0 0 18 * * *")
     fun notifyMatching() {
-        val users = userService.findAllByNotDeleted()
-        val fcmTokens = fcmTokenService.findByUsers(users)
+        val userIds = userService.findAllByNotDeleted().map { it.id }
+        val fcmTokens = fcmTokenService.findAllByUserIds(userIds)
         val tokens = fcmTokens.map { it.token }
 
         val fcmNotification = FcmNotification(


### PR DESCRIPTION
## 💡 이슈 번호
close: #335 

## ✨ 작업 내용
- 토큰 조회 시 빈 값을 제외하여 조회하도록 했습니다.

## 🚀 전달 사항
<img width="1038" alt="스크린샷 2024-08-25 오전 12 48 07" src="https://github.com/user-attachments/assets/c4e84b3b-3baf-4edc-891a-6831a3de5332">
스케줄러 잘 도는 것은 확인했고, 디비에 토큰 값이 빈 값으로 저장된 데이터들이 있어서 오류가 났던거였어요!