### PR TITLE
[Feature/354] 만료된 보틀 보여주지 않기 / fcm 토큰 업데이트 api 

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/controller/AuthController.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/controller/AuthController.kt
@@ -1,20 +1,7 @@
 package com.nexters.bottles.api.auth.controller
 
 import com.nexters.bottles.api.auth.facade.AuthFacade
-import com.nexters.bottles.api.auth.facade.dto.AppleRevokeResponse
-import com.nexters.bottles.api.auth.facade.dto.AppleSignInUpRequest
-import com.nexters.bottles.api.auth.facade.dto.AppleSignInUpResponse
-import com.nexters.bottles.api.auth.facade.dto.AuthSmsRequest
-import com.nexters.bottles.api.auth.facade.dto.KakaoSignInUpRequest
-import com.nexters.bottles.api.auth.facade.dto.KakaoSignInUpResponse
-import com.nexters.bottles.api.auth.facade.dto.LogoutRequest
-import com.nexters.bottles.api.auth.facade.dto.ReissueTokenRequest
-import com.nexters.bottles.api.auth.facade.dto.ReissueTokenResponse
-import com.nexters.bottles.api.auth.facade.dto.SendSmsResponse
-import com.nexters.bottles.api.auth.facade.dto.SignUpResponse
-import com.nexters.bottles.api.auth.facade.dto.SmsSendRequest
-import com.nexters.bottles.api.auth.facade.dto.SmsSignInRequest
-import com.nexters.bottles.api.auth.facade.dto.SmsSignInResponse
+import com.nexters.bottles.api.auth.facade.dto.*
 import com.nexters.bottles.api.global.interceptor.AuthRequired
 import com.nexters.bottles.api.global.interceptor.RefreshAuthRequired
 import com.nexters.bottles.api.global.resolver.AccessToken
@@ -99,5 +86,12 @@ class AuthController(
     @AuthRequired
     fun getAppleClientSecret(): AppleRevokeResponse {
         return authFacade.getAppleClientSecret()
+    }
+
+    @ApiOperation("fcm 토큰 갱신")
+    @PostMapping("/fcm")
+    @AuthRequired
+    fun insertFcmToken(@AuthUserId userId: Long, @RequestBody fcmUpdateRequest: FcmUpdateRequest) {
+        authFacade.updateFcmToken(userId, fcmUpdateRequest.fcmToken)
     }
 }

--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/facade/AuthFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/facade/AuthFacade.kt
@@ -273,6 +273,10 @@ class AuthFacade(
         return AppleRevokeResponse(clientSecret = clientSecret)
     }
 
+    fun updateFcmToken(userId: Long, fcmToken: String) {
+        fcmTokenService.registerFcmToken(userId, fcmToken)
+    }
+
     private fun isSuperUser(phoneNumber: String) = phoneNumber == superUserNumber
 }
 

--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/facade/dto/FcmUpdateRequest.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/facade/dto/FcmUpdateRequest.kt
@@ -1,0 +1,6 @@
+package com.nexters.bottles.api.auth.facade.dto
+
+data class FcmUpdateRequest(
+    val fcmToken: String,
+) {
+}

--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacade.kt
@@ -180,6 +180,7 @@ class BottleFacade(
             ?: emptyList()
         val doneBottles =
             (groupByStatus[PingPongStatus.STOPPED].orEmpty() + groupByStatus[PingPongStatus.MATCHED].orEmpty())
+                .filter { it.isNotExpired(LocalDateTime.now()) }
                 .map { toPingPongBottleDto(it, user) }
                 .filter { it.userId !in blockedUserIds }
         return PingPongListResponse(activeBottles = activeBottles, doneBottles = doneBottles)

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/domain/Bottle.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/domain/Bottle.kt
@@ -126,6 +126,14 @@ class Bottle(
         return bottleStatus == BottleStatus.SENT && pingPongStatus == PingPongStatus.NONE
     }
 
+    fun isExpired(now: LocalDateTime): Boolean {
+        return expiredAt.plusDays(1L) <= now
+    }
+
+    fun isNotExpired(now: LocalDateTime): Boolean {
+        return !isExpired(now)
+    }
+
     companion object {
         private const val DELETE_AFTER_DAYS = 3
     }

--- a/app/src/main/kotlin/com/nexters/bottles/app/notification/component/FcmClient.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/notification/component/FcmClient.kt
@@ -5,11 +5,17 @@ import com.google.firebase.messaging.Message
 import com.google.firebase.messaging.MulticastMessage
 import com.google.firebase.messaging.Notification
 import com.nexters.bottles.app.notification.component.dto.FcmNotification
+import com.nexters.bottles.app.notification.repository.FcmTokenRepository
+import mu.KotlinLogging
 import org.springframework.stereotype.Component
 
 
 @Component
-class FcmClient {
+class FcmClient(
+    private val fcmTokenRepository: FcmTokenRepository,
+) {
+
+    private val log = KotlinLogging.logger { }
 
     fun sendNotificationTo(userToken: String, fcmNotification: FcmNotification): String? {
         val notification = makeNotification(fcmNotification)
@@ -17,7 +23,14 @@ class FcmClient {
             .setNotification(notification)
             .setToken(userToken)
             .build()
-        return FirebaseMessaging.getInstance().send(message)
+
+        try {
+            return FirebaseMessaging.getInstance().send(message)
+        } catch (e: Exception) {
+            fcmTokenRepository.deleteByToken(userToken)
+            log.info { "fcmToken 404 예외 - 더이상 유효하지 않아 삭제 $userToken" }
+            return null
+        }
     }
 
     fun sendNotificationAll(userTokens: List<String>, fcmNotification: FcmNotification) {

--- a/app/src/main/kotlin/com/nexters/bottles/app/notification/repository/FcmTokenRepository.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/notification/repository/FcmTokenRepository.kt
@@ -12,4 +12,6 @@ interface FcmTokenRepository : JpaRepository<FcmToken, Long> {
     fun findByUserIdAndToken(userId: Long, token: String): FcmToken?
 
     fun findAllByUserIdIn(@Param("userIds") userIds: List<Long>): List<FcmToken>
+
+    fun deleteByToken(userToken: String)
 }


### PR DESCRIPTION
## 💡 이슈 번호
close: #354 

## ✨ 작업 내용
1. fcm 토큰 등록 api 분리
- 클라이언트에서는 로컬에 fcm 토큰 가지고 있다가 변경되면 이 api를 호출합니다
- 한 유저는 n개의 토큰을 가질 수 있습니다.
- 토큰의 생성일을 보고 m개월이 지나면 유효하지 않다 판단합니다 (아직 이 숫자를 몰라 구현하지 않았습니다)
- fcm에서 응답으로 not found 가 오면 유효하지 않은 토큰이니 삭제합니다

2. 완료된 보틀에서 expired면 안보이게 필터링했습니다. 추후 배치에서 삭제로 변경 예정입니다

## 🚀 전달 사항
