### PR TITLE
feat: 마지막 활성화 시간 임시 null 처리

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacade.kt
@@ -117,7 +117,8 @@ class BottleFacade(
             keyword = bottle.sourceUser.userProfile?.profileSelect?.keyword,
             userImageUrl = bottle.sourceUser.userProfile?.imageUrl,
             expiredAt = bottle.expiredAt,
-            lastActivatedAt = getLastActivatedAtInKorean(basedAt = bottle.sourceUser.lastActivatedAt, now = LocalDateTime.now())
+            //lastActivatedAt = getLastActivatedAtInKorean(basedAt = bottle.sourceUser.lastActivatedAt, now = LocalDateTime.now())
+            lastActivatedAt = null,
         )
     }
 
@@ -204,7 +205,8 @@ class BottleFacade(
             mbti = otherUser.userProfile?.profileSelect?.mbti,
             keyword = otherUser.userProfile?.profileSelect?.keyword,
             userImageUrl = otherUser.userProfile?.imageUrl,
-            lastActivatedAt = getLastActivatedAtInKorean(basedAt = otherUser.lastActivatedAt, now = LocalDateTime.now())
+            //lastActivatedAt = getLastActivatedAtInKorean(basedAt = otherUser.lastActivatedAt, now = LocalDateTime.now()),
+            lastActivatedAt = null,
         )
     }
 


### PR DESCRIPTION
## 💡 이슈 번호
close: #369 

## ✨ 작업 내용
안드로이드에서 새로운 필드가 추가될때 상위호환 되게 안해놔서 임시로 null을 반환합니다

## 🚀 전달 사항
