### PR TITLE
[Feature/367] 매칭 활성/비활성화 API를 구현한다

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/user/controller/UserProfileController.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/user/controller/UserProfileController.kt
@@ -3,7 +3,14 @@ package com.nexters.bottles.api.user.controller
 import com.nexters.bottles.api.global.interceptor.AuthRequired
 import com.nexters.bottles.api.global.resolver.AuthUserId
 import com.nexters.bottles.api.user.facade.UserProfileFacade
-import com.nexters.bottles.api.user.facade.dto.*
+import com.nexters.bottles.api.user.facade.dto.ActivateMatchingRequest
+import com.nexters.bottles.api.user.facade.dto.ExistIntroductionResponse
+import com.nexters.bottles.api.user.facade.dto.ProfileChoiceResponse
+import com.nexters.bottles.api.user.facade.dto.RegisterIntroductionRequest
+import com.nexters.bottles.api.user.facade.dto.RegisterProfileRequest
+import com.nexters.bottles.api.user.facade.dto.UserInfoResponse
+import com.nexters.bottles.api.user.facade.dto.UserProfileResponse
+import com.nexters.bottles.api.user.facade.dto.UserProfileStatusResponse
 import io.swagger.annotations.ApiOperation
 import mu.KotlinLogging
 import org.springframework.web.bind.annotation.GetMapping
@@ -19,7 +26,7 @@ import org.springframework.web.multipart.MultipartFile
 class UserProfileController(
     private val profileFacade: UserProfileFacade,
 ) {
-    
+
     private val log = KotlinLogging.logger {}
 
     @ApiOperation("온보딩 프로필 등록하기")
@@ -80,5 +87,12 @@ class UserProfileController(
     @AuthRequired
     fun findStatus(@AuthUserId userId: Long): UserProfileStatusResponse {
         return profileFacade.findUserProfileStatus(userId)
+    }
+
+    @ApiOperation("매칭 활성/비활성화")
+    @PostMapping("/activate/matching")
+    @AuthRequired
+    fun activateAccount(@AuthUserId userId: Long, @RequestBody activateMatchingRequest: ActivateMatchingRequest) {
+        profileFacade.activateMatching(userId, activateMatchingRequest)
     }
 }

--- a/api/src/main/kotlin/com/nexters/bottles/api/user/facade/UserFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/user/facade/UserFacade.kt
@@ -10,7 +10,6 @@ class UserFacade(
     private val userReportService: UserReportService,
 ) {
 
-
     fun reportUser(userId: Long, reportUserRequest: ReportUserRequest) {
         userReportService.saveReport(
             UserReport(

--- a/api/src/main/kotlin/com/nexters/bottles/api/user/facade/UserProfileFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/user/facade/UserProfileFacade.kt
@@ -80,7 +80,8 @@ class UserProfileFacade(
             age = user.getKoreanAge(),
             imageUrl = userProfile?.imageUrl,
             introduction = userProfile?.introduction ?: emptyList(),
-            profileSelect = userProfile?.profileSelect
+            profileSelect = userProfile?.profileSelect,
+            isMatchActivated = user.isMatchActivated
         )
     }
 

--- a/api/src/main/kotlin/com/nexters/bottles/api/user/facade/UserProfileFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/user/facade/UserProfileFacade.kt
@@ -1,5 +1,6 @@
 package com.nexters.bottles.api.user.facade
 
+import com.nexters.bottles.api.user.facade.dto.ActivateMatchingRequest
 import com.nexters.bottles.api.user.facade.dto.ExistIntroductionResponse
 import com.nexters.bottles.api.user.facade.dto.ProfileChoiceResponse
 import com.nexters.bottles.api.user.facade.dto.RegisterIntroductionRequest
@@ -72,7 +73,6 @@ class UserProfileFacade(
     }
 
     fun getMyProfile(userId: Long): UserProfileResponse {
-
         val userProfile = profileService.findUserProfile(userId)
         val user = userProfile?.user ?: userService.findByIdAndNotDeleted(userId)
         return UserProfileResponse(
@@ -171,6 +171,10 @@ class UserProfileFacade(
             userProfile != null -> UserProfileStatus.ONLY_PROFILE_CREATED
             else -> UserProfileStatus.EMPTY
         }
+    }
+
+    fun activateMatching(userId: Long, activateMatchingRequest: ActivateMatchingRequest) {
+        userService.activateMatching(userId, activateMatchingRequest.activate)
     }
 
     companion object {

--- a/api/src/main/kotlin/com/nexters/bottles/api/user/facade/dto/ActivateMatchingRequest.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/user/facade/dto/ActivateMatchingRequest.kt
@@ -1,0 +1,7 @@
+package com.nexters.bottles.api.user.facade.dto
+
+data class ActivateMatchingRequest(
+    val activate: Boolean
+) {
+
+}

--- a/api/src/main/kotlin/com/nexters/bottles/api/user/facade/dto/UserProfileResponse.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/user/facade/dto/UserProfileResponse.kt
@@ -9,5 +9,6 @@ data class UserProfileResponse(
     val imageUrl: String? = null,
     val introduction: List<QuestionAndAnswer>,
     val profileSelect: UserProfileSelect? = null,
+    val isMatchActivated: Boolean? = true
 ) {
 }

--- a/app/src/main/kotlin/com/nexters/bottles/app/notification/component/FcmNotificationScheduler.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/notification/component/FcmNotificationScheduler.kt
@@ -15,7 +15,7 @@ class FcmNotificationScheduler(
 
     @Scheduled(cron = "0 0 18 * * *")
     fun notifyMatching() {
-        val userIds = userService.findAllByNotDeleted().map { it.id }
+        val userIds = userService.findAllByDeletedFalseAndMatchActivatedTrue().map { it.id }
         val fcmTokens = fcmTokenService.findAllByUserIdsAndTokenNotBlank(userIds)
         val tokens = fcmTokens.map { it.token }
 
@@ -25,4 +25,6 @@ class FcmNotificationScheduler(
         )
         fcmClient.sendNotificationAll(userTokens = tokens, fcmNotification = fcmNotification)
     }
+
+    // TODO 매칭 비활성화 된 유저에게 푸시 알림 보내기
 }

--- a/app/src/main/kotlin/com/nexters/bottles/app/user/component/event/UserProfileApplicationEventListener.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/user/component/event/UserProfileApplicationEventListener.kt
@@ -4,9 +4,9 @@ import com.nexters.bottles.app.bottle.service.BottleHistoryService
 import com.nexters.bottles.app.bottle.service.BottleService
 import com.nexters.bottles.app.user.component.event.dto.IntroductionSaveEventDto
 import com.nexters.bottles.app.user.service.UserService
-import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionalEventListener
 
 @Component
 class UserProfileApplicationEventListener(
@@ -16,7 +16,7 @@ class UserProfileApplicationEventListener(
 ) {
 
     @Async
-    @EventListener
+    @TransactionalEventListener
     fun handleCustomEvent(event: IntroductionSaveEventDto) {
         val user = userService.findByIdAndNotDeleted(event.userId)
         bottleService.matchFirstRandomBottle(user)?.let {

--- a/app/src/main/kotlin/com/nexters/bottles/app/user/repository/UserRepository.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/user/repository/UserRepository.kt
@@ -9,7 +9,7 @@ interface UserRepository : JpaRepository<User, Long> {
 
     fun findByIdAndDeletedFalse(id: Long): User?
 
-    fun findAllByDeletedFalse(): List<User>
+    fun findAllByDeletedFalseAndIsMatchActivatedTrue(): List<User>
 
     fun findByPhoneNumber(phoneNumber: String): User?
 

--- a/app/src/main/kotlin/com/nexters/bottles/app/user/service/UserProfileService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/user/service/UserProfileService.kt
@@ -44,7 +44,6 @@ class UserProfileService(
         profileRepository.findByUserId(user.id)?.let {
             val isFirstRegisterIntroduction = it.introduction.isEmpty()
             it.introduction = introduction
-            // TODO introduction 저장 실패시 이벤트 처리 수정
             if (isFirstRegisterIntroduction) {
                 applicationEventPublisher.publishEvent(
                     IntroductionSaveEventDto(userId = userId)

--- a/app/src/main/kotlin/com/nexters/bottles/app/user/service/UserService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/user/service/UserService.kt
@@ -159,4 +159,11 @@ class UserService(
             it.deletedAt = null
         }
     }
+
+    @Transactional
+    fun activateMatching(userId: Long, activate: Boolean) {
+        userRepository.findByIdAndDeletedFalse(userId)?.let { user ->
+            user.isMatchActivated = activate
+        } ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
+    }
 }

--- a/app/src/main/kotlin/com/nexters/bottles/app/user/service/UserService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/user/service/UserService.kt
@@ -128,8 +128,8 @@ class UserService(
     }
 
     @Transactional(readOnly = true)
-    fun findAllByNotDeleted(): List<User> {
-        return userRepository.findAllByDeletedFalse()
+    fun findAllByDeletedFalseAndMatchActivatedTrue(): List<User> {
+        return userRepository.findAllByDeletedFalseAndIsMatchActivatedTrue()
     }
 
     @Transactional

--- a/batch/src/main/kotlin/com/nexters/bottles/batch/scheduler/FcmNotificationScheduler.kt
+++ b/batch/src/main/kotlin/com/nexters/bottles/batch/scheduler/FcmNotificationScheduler.kt
@@ -16,7 +16,7 @@ class FcmNotificationScheduler(
 
     @Scheduled(cron = "0 0 18 * * *")
     fun notifyMatching() {
-        val userIds = userService.findAllByNotDeleted().map { it.id }
+        val userIds = userService.findAllByDeletedFalseAndMatchActivatedTrue().map { it.id }
         val fcmTokens = fcmTokenService.findAllByUserIdsAndTokenNotBlank(userIds)
         val tokens = fcmTokens.map { it.token }
 


### PR DESCRIPTION
## 💡 이슈 번호
close: #367 

## ✨ 작업 내용
- 매칭 활성, 비활성화 하는 api를 구현했습니다.
- 이에 따라 매칭 활성화된 유저에게만 랜덤 매칭 푸시 알림을 보내도록 수정했습니다.
- 내 프로필 조회 API에 매칭 활성화 여부를 내려주도록 추가했습니다.

## 🚀 전달 사항
- 안드로이드 호환 문제로 다음 업데이트 이후 배포하도록 할게요!