### PR TITLE
[Fix/374] 사용자 탈퇴 시 진행중인 핑퐁이 중단되도록 한다

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/component/AuthApplicationEventListener.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/component/AuthApplicationEventListener.kt
@@ -27,9 +27,9 @@ class AuthApplicationEventListener(
 
         val pingPongBottles = bottleService.getPingPongBottlesByDeletedUser(event.userId)
         pingPongBottles.forEach {
-            val stoppedBottle = bottleService.stopByDeletedUser(userId = event.userId, bottle = it)
-            bottleCachingService.evictPingPongList(stoppedBottle.sourceUser.id, stoppedBottle.targetUser.id)
+            bottleCachingService.evictPingPongList(it.sourceUser.id, it.targetUser.id)
         }
+        bottleService.stopPingPongBottlesByDeletedUser(event.userId)
 
         fcmTokenService.deleteAllFcmTokenByUserId(event.userId)
     }

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/repository/BottleRepository.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/repository/BottleRepository.kt
@@ -35,8 +35,8 @@ interface BottleRepository : JpaRepository<Bottle, Long> {
 
     @Query(
         value = "SELECT b FROM Bottle b " +
-                "WHERE (b.targetUser = :user AND b.targetUser.deleted = false) " +
-                "OR (b.sourceUser = :user AND b.sourceUser.deleted = false ) " +
+                "WHERE ((b.targetUser = :user AND b.targetUser.deleted = false) " +
+                "OR (b.sourceUser = :user AND b.sourceUser.deleted = false )) " +
                 "AND b.pingPongStatus IN :pingPongStatus " +
                 "AND b.deleted = false "
     )
@@ -47,7 +47,7 @@ interface BottleRepository : JpaRepository<Bottle, Long> {
 
     @Query(
         value = "SELECT b FROM Bottle b " +
-                "WHERE b.targetUser = :user OR b.sourceUser = :user " +
+                "WHERE (b.targetUser = :user OR b.sourceUser = :user) " +
                 "AND b.pingPongStatus IN :pingPongStatus " +
                 "AND b.deleted = false "
     )

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleService.kt
@@ -207,18 +207,25 @@ class BottleService(
         return bottleRepository.findAllByUserAndStatusAndDeletedFalse(
             user,
             setOf(
-                PingPongStatus.NONE,
                 PingPongStatus.ACTIVE,
+                PingPongStatus.STOPPED,
                 PingPongStatus.MATCHED,
             )
         )
     }
 
     @Transactional
-    fun stopByDeletedUser(userId: Long, bottle: Bottle): Bottle {
-        val stoppedUser = userRepository.findByIdOrNull(userId) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
-        bottle.stop(stoppedUser, LocalDateTime.now())
-        return bottle
+    fun stopPingPongBottlesByDeletedUser(userId: Long) {
+        val user = userRepository.findByIdOrNull(userId) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
+        val pingPongBottles = bottleRepository.findAllByUserAndStatusAndDeletedFalse(
+            user,
+            setOf(
+                PingPongStatus.ACTIVE,
+            )
+        )
+        pingPongBottles.forEach {
+            it.stop(user, LocalDateTime.now())
+        }
     }
 
     @Transactional

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleService.kt
@@ -217,13 +217,13 @@ class BottleService(
     @Transactional
     fun stopPingPongBottlesByDeletedUser(userId: Long) {
         val user = userRepository.findByIdOrNull(userId) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
-        val pingPongBottles = bottleRepository.findAllByUserAndStatusAndDeletedFalse(
+        val activeBottles = bottleRepository.findAllByUserAndStatusAndDeletedFalse(
             user,
             setOf(
                 PingPongStatus.ACTIVE,
             )
         )
-        pingPongBottles.forEach {
+        activeBottles.forEach {
             it.stop(user, LocalDateTime.now())
         }
     }


### PR DESCRIPTION
## 💡 이슈 번호
close: #374 

## ✨ 작업 내용
- 사용자 탈퇴 시 진행중인 핑퐁을 중단하는 로직을 수정했습니다.

## 🚀 전달 사항
- 쿼리에서 or와 and 구문에 오류가 있어서 수정했습니다.
- 기존에 탈퇴 후 발행된 이벤트 로직에서
bottle.stop을 호출하면 변경감지를 통해 update 쿼리가 날아갈 것이라고 생각했는데, 한 transaction 안에서 bottle을 조회하지 않기 때문에 영속성 컨텍스트에 존재하지 않아서 변경감지를 하지 못하고 있더라구요! 이 부분 수정했습니다.