### PR TITLE
[Feature/381] 보틀 히스토리 저장 시점을 변경한다

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/event/AuthApiEventListener.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/event/AuthApiEventListener.kt
@@ -1,7 +1,6 @@
 package com.nexters.bottles.api.auth.event
 
 import com.nexters.bottles.api.auth.event.dto.SignUpEventDto
-import com.nexters.bottles.api.bottle.event.dto.BottleStopEventDto
 import com.nexters.bottles.app.notification.component.FcmClient
 import com.nexters.bottles.app.notification.component.dto.FcmNotification
 import com.nexters.bottles.app.notification.service.FcmTokenService
@@ -16,13 +15,13 @@ class AuthApiEventListener(
     private val fcmClient: FcmClient,
 ) {
 
-    private val log = KotlinLogging.logger {  }
+    private val log = KotlinLogging.logger { }
 
     @Async
     @EventListener
     fun handleCustomEvent(event: SignUpEventDto) {
         val fcmNotification = FcmNotification(
-            title = "똑똑똑! ${event.userName}님에게 보틀이 도착했어요 \uD83D\uDC40",
+            title = "똑똑똑! ${event.userName}님에게 보틀이 도착했어요 👀",
             body = "보틀을 확인하기 위해서는 자기소개 작성이 꼭 필요해요!\n" +
                     "자기소개를 작성하러 가볼까요?"
         )

--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/event/BottleApiEventListener.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/event/BottleApiEventListener.kt
@@ -28,7 +28,7 @@ class BottleApiEventListener(
     private val userService: UserService,
 ) {
 
-    private val log = KotlinLogging.logger {  }
+    private val log = KotlinLogging.logger { }
 
     @Async
     @EventListener
@@ -57,22 +57,25 @@ class BottleApiEventListener(
                     fcmClient.sendNotificationTo(userToken = it.token, fcmNotification = fcmNotification)
                     log.info { "[BottleAcceptEventDto] 호감 보냄 bottleId: ${bottle.id} targetUserId: ${bottle.targetUser.id} sourceUserId: ${bottle.sourceUser.id} sourceUserToken: ${it.token}" }
                 }
+
+                bottleHistoryService.saveMatchingHistory(bottle.sourceUser.id, bottle.targetUser.id)
             }
 
             bottle.isActive() -> {
-                fcmTokenService.findAllByUserIdsAndTokenNotBlank(listOf(bottle.sourceUser.id, bottle.targetUser.id)).forEach {
-                    val fcmNotification = FcmNotification(
-                        title = "${findOtherUserName(it.userId, bottle)}님과의 문답이 시작됐어요! 💌",
-                        body = "어떤 질문이 기다리고 있을까요?\n지금부터 서로를 더 깊게 알아보세요!"
-                    )
-                    fcmClient.sendNotificationTo(userToken = it.token, fcmNotification = fcmNotification)
-                    log.info { "[BottleAcceptEventDto] 문답 시작 bottleId: ${bottle.id} userId: ${it.userId} token: ${it.token}" }
-                }
+                fcmTokenService.findAllByUserIdsAndTokenNotBlank(listOf(bottle.sourceUser.id, bottle.targetUser.id))
+                    .forEach {
+                        val fcmNotification = FcmNotification(
+                            title = "${findOtherUserName(it.userId, bottle)}님과의 문답이 시작됐어요! 💌",
+                            body = "어떤 질문이 기다리고 있을까요?\n지금부터 서로를 더 깊게 알아보세요!"
+                        )
+                        fcmClient.sendNotificationTo(userToken = it.token, fcmNotification = fcmNotification)
+                        log.info { "[BottleAcceptEventDto] 문답 시작 bottleId: ${bottle.id} userId: ${it.userId} token: ${it.token}" }
+                    }
             }
         }
     }
 
-    private fun findOtherUserName(userId: Long, bottle: Bottle): String? {
+    private fun findOtherUserName(userId: Long, bottle: Bottle): String {
         return if (userId == bottle.sourceUser.id) bottle.targetUser.getMaskedName() else bottle.sourceUser.getMaskedName()
     }
 

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleHistoryService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleHistoryService.kt
@@ -12,9 +12,8 @@ class BottleHistoryService(
 
     @Transactional
     fun saveMatchingHistory(sourceUserId: Long, targetUserId: Long) {
-        val sourceUserBottleHistory = BottleHistory(userId = sourceUserId, matchedUserId = targetUserId)
         val targetUserBottleHistory = BottleHistory(userId = targetUserId, matchedUserId = sourceUserId)
-        bottleHistoryRepository.saveAll(listOf(sourceUserBottleHistory, targetUserBottleHistory))
+        bottleHistoryRepository.save(targetUserBottleHistory)
     }
 
     @Transactional


### PR DESCRIPTION
## 💡 이슈 번호
close: #381 

## ✨ 작업 내용
- 보틀 히스토리 저장 시점을 변경했습니다.

## 🚀 전달 사항
- 기존에는 a <- b 랜덤 매칭 시, (`userId`: a, `matchedUserId`: b), (b, a) 모두 저장되었는데
이를 (a, b)만 저장되도록 변경했습니다.
이후 a가 b에게 호감을 보내면 그때 (b, a)가 저장되도록 했습니다.