### PR TITLE
[Feature/380] 앱 업데이트 버전을 조회하는 API를 구현한다

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/controller/AuthController.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/controller/AuthController.kt
@@ -94,4 +94,12 @@ class AuthController(
     fun insertFcmToken(@AuthUserId userId: Long, @RequestBody fcmUpdateRequest: FcmUpdateRequest) {
         authFacade.updateFcmToken(userId, fcmUpdateRequest.fcmToken)
     }
+
+    @ApiOperation("")
+    @PostMapping("/app-version")
+    fun getUpdateAppVersion(): UpdateAppVersionResponse {
+        return UpdateAppVersionResponse(
+
+        )
+    }
 }

--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/controller/AuthController.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/controller/AuthController.kt
@@ -95,7 +95,7 @@ class AuthController(
         authFacade.updateFcmToken(userId, fcmUpdateRequest.fcmToken)
     }
 
-    @ApiOperation("")
+    @ApiOperation("업데이트 해야하는 앱 버전 조회")
     @PostMapping("/app-version")
     fun getUpdateAppVersion(): UpdateAppVersionResponse {
         return UpdateAppVersionResponse(

--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/facade/dto/UpdateAppVersionResponse.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/facade/dto/UpdateAppVersionResponse.kt
@@ -1,0 +1,7 @@
+package com.nexters.bottles.api.auth.facade.dto
+
+data class UpdateAppVersionResponse(
+    val minimumIosVersion: String? = null, // 이 버전 미만이면 강제 업데이트를 해야합니다
+    val minimumAndroidVersion: String? = null,
+) {
+}


### PR DESCRIPTION
## 💡 이슈 번호
close: #380 

## ✨ 작업 내용
앱 업데이트 버전을 조회하는 API를 구현한다

## 🚀 전달 사항
이거 업데이트 해야하는 앱 버전을 어떻게 해야할지 고민이네요! 일단은 환경변수에 넣거나, 서버에 하드코딩 넣어서 배포해도 될거같아요!

 api 뚫을까 생각도 했는데, 그러면 휴먼 에러 발생 확률도 높고, 저희가 아직 저희만 사용 가능한 어드민이 아니라 path 알아내면 누구나 호출할 수 있으니.. 