### PR TITLE
[Feature/438] 리프레시 토큰 만료 검증 추가

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/auth/component/JwtTokenProvider.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/auth/component/JwtTokenProvider.kt
@@ -83,10 +83,7 @@ class JwtTokenProvider(
     }
 
     fun validateToken(token: String, isAccessToken: Boolean): Boolean {
-        var expiredAccessToken: BlackList? = null
-        if (isAccessToken) {
-            expiredAccessToken = blackListService.findLastExpiredToken(token)
-        }
+        var expiredAccessToken = blackListService.findLastExpiredToken(token)
         val claims = getClaimsFromToken(token, isAccessToken)
         val now = Date()
         return expiredAccessToken == null && claims != null && !claims.expiration.before(now)

--- a/api/src/main/resources/sql/ddl/table_query.sql
+++ b/api/src/main/resources/sql/ddl/table_query.sql
@@ -114,8 +114,9 @@ CREATE TABLE black_list
 (
     id                   BIGINT AUTO_INCREMENT PRIMARY KEY,
     expired_access_token VARCHAR(512)                       NOT NULL,
+    token_type           VARCHAR(50)                        NOT NULL DEFAULT 'ACCESS_TOKEN' comment 'ACCESS_TOKEN, REFRESH_TOKEN',
     created_at           DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    updated_at           DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL
+    updated_at           DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP
 );
 CREATE INDEX idx_expired_access_token ON black_list (expired_access_token);
 

--- a/app/src/main/kotlin/com/nexters/bottles/app/admin/service/AdminService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/admin/service/AdminService.kt
@@ -1,6 +1,7 @@
 package com.nexters.bottles.app.admin.service
 
 import com.nexters.bottles.app.auth.domain.BlackList
+import com.nexters.bottles.app.auth.domain.enum.TokenType
 import com.nexters.bottles.app.auth.repository.BlackListRepository
 import com.nexters.bottles.app.auth.repository.RefreshTokenRepository
 import com.nexters.bottles.app.bottle.domain.Bottle
@@ -48,8 +49,12 @@ class AdminService(
     @TestOnly
     @Transactional
     fun expireRefreshToken(token: String, userId: Long) {
-        refreshTokenRepository.findAllByUserId(userId)
-            .forEach { refreshTokenRepository.deleteById(it.id) }
+        blackListRepository.save(
+            BlackList(
+                expiredAccessToken = token,
+                tokenType = TokenType.REFRESH_TOKEN
+            )
+        )
     }
 
     @TestOnly

--- a/app/src/main/kotlin/com/nexters/bottles/app/auth/domain/BlackList.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/auth/domain/BlackList.kt
@@ -1,10 +1,8 @@
 package com.nexters.bottles.app.auth.domain
 
+import com.nexters.bottles.app.auth.domain.enum.TokenType
 import com.nexters.bottles.app.common.BaseEntity
-import javax.persistence.Entity
-import javax.persistence.GeneratedValue
-import javax.persistence.GenerationType
-import javax.persistence.Id
+import javax.persistence.*
 
 @Entity
 class BlackList(
@@ -12,5 +10,8 @@ class BlackList(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,
 
-    val expiredAccessToken: String,
+    @Enumerated(EnumType.STRING)
+    val tokenType: TokenType = TokenType.ACCESS_TOKEN,
+
+    val expiredAccessToken: String, // refreshToken도 저장할 수 있게 변경되었으나 과거에 작성한 변수명이라 그냥 둠
 ) : BaseEntity()

--- a/app/src/main/kotlin/com/nexters/bottles/app/auth/domain/enum/TokenType.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/auth/domain/enum/TokenType.kt
@@ -1,0 +1,7 @@
+package com.nexters.bottles.app.auth.domain.enum
+
+enum class TokenType {
+    ACCESS_TOKEN,
+    REFRESH_TOKEN,
+    ;
+}


### PR DESCRIPTION
## 💡 이슈 번호
close: #438 

## ✨ 작업 내용
리프레시 토큰 만료 검증 추가

## 🚀 전달 사항
db에 컬럼 추가해놨고, 디폴트값 ACCESS_TOKEN으로 설정해놨어요