### PR TITLE
[Feature/445] 보틀 조회 V2 API 구현한다

### DIFF
--- a/.github/workflows/daily-scrum-notification.yml
+++ b/.github/workflows/daily-scrum-notification.yml
@@ -14,12 +14,20 @@ jobs:
           DATA: |
             {
               "channel": "C07LHAWLVNG", 
-              "text": "<@U07L8AX9B4N><@U07L87A3WKY><@U07LC3Q1MEH><@U07LHEEU2BW><@U07LESGBQEP><@U07LMP4PY0L><@U07LHAXGYBE><@U07L87GGHJS>
-            **:calendar: 보틀즈 데일리 스크럼 :calendar:**\n\n
-            :one: - 완료된 작업 내용\n\n
-            :two: - 오늘 해야 할 작업\n\n
-            :three: - 겪고 있는 문제나 도움이 필요한 사항\n\n
-            오늘의 TMI나 아무말도 좋아:blob_aww: \n\n",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<@U07L8AX9B4N><@U07L87A3WKY><@U07LC3Q1MEH><@U07LHEEU2BW><@U07LESGBQEP><@U07LMP4PY0L><@U07LHAXGYBE><@U07L87GGHJS>\n\n
+                            *:calendar: 보틀즈 데일리 스크럼 :calendar:*\n\n
+                            :one: - 완료된 작업 내용\n\n
+                            :two: - 오늘 해야 할 작업\n\n
+                            :three: - 겪고 있는 문제나 도움이 필요한 사항\n\n
+                            오늘의 TMI나 아무말도 좋아 :blob_aww: \n\n"
+                  }
+                }
+              ]
             }
         run: |
           curl -X POST -H "Content-Type: application/json" \

--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/controller/BottleController.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/controller/BottleController.kt
@@ -12,7 +12,6 @@ import com.nexters.bottles.api.bottle.facade.dto.RegisterLetterRequest
 import com.nexters.bottles.api.global.interceptor.AuthRequired
 import com.nexters.bottles.api.global.resolver.AuthUserId
 import io.swagger.annotations.ApiOperation
-import mu.KotlinLogging
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -25,9 +24,7 @@ import org.springframework.web.bind.annotation.RestController
 class BottleController(
     private val bottleFacade: BottleFacade
 ) {
-
-    private val log = KotlinLogging.logger {}
-
+    
     @ApiOperation("홈 - 받은 보틀 목록 조회하기")
     @GetMapping
     @AuthRequired
@@ -60,7 +57,7 @@ class BottleController(
         bottleFacade.refuseBottle(userId, bottleId)
     }
 
-    @ApiOperation("보틀 보관함 - 보틀 보관함 조회하기")
+    @ApiOperation("문답 - 핑퐁중인 보틀 조회하기")
     @GetMapping("/ping-pong")
     @AuthRequired
     fun getPingPongList(@AuthUserId userId: Long): PingPongListResponse {

--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/controller/BottleControllerV2.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/controller/BottleControllerV2.kt
@@ -1,0 +1,32 @@
+package com.nexters.bottles.api.bottle.controller
+
+import com.nexters.bottles.api.bottle.facade.BottleFacadeV2
+import com.nexters.bottles.api.bottle.facade.dto.RandomBottleListResponse
+import com.nexters.bottles.api.bottle.facade.dto.SentBottleListResponse
+import com.nexters.bottles.api.global.interceptor.AuthRequired
+import com.nexters.bottles.api.global.resolver.AuthUserId
+import io.swagger.annotations.ApiOperation
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v2/bottles")
+class BottleControllerV2(
+    private val bottleFacadeV2: BottleFacadeV2
+) {
+
+    @ApiOperation("모래사장 - 랜덤으로 받은 보틀 목록 조회하기")
+    @GetMapping("/random")
+    @AuthRequired
+    fun getRandomBottlesList(@AuthUserId userId: Long): RandomBottleListResponse {
+        return bottleFacadeV2.getRandomBottles(userId)
+    }
+
+    @ApiOperation("호감 - 호감을 받은 보틀 목록 조회하기")
+    @GetMapping("/sent")
+    @AuthRequired
+    fun getSentBottlesList(@AuthUserId userId: Long): SentBottleListResponse {
+        return bottleFacadeV2.getSentBottles(userId)
+    }
+}

--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacade.kt
@@ -61,9 +61,10 @@ class BottleFacade(
 
     fun getNewBottles(userId: Long): BottleListResponse {
         val user = userService.findByIdAndNotDeleted(userId)
-        val blockUserIds = blockContactListService.findAllByUserId(userId).map{ it.userId }.toSet() // 내가 차단한 유저
-        val blockedMeUserIds = blockContactListService.findAllByPhoneNumber(user.phoneNumber ?: throw IllegalStateException("핸드폰 번호를 등록해주세요"))
-            .map{ it.userId }.toSet() // 나를 차단한 유저
+        val blockUserIds = blockContactListService.findAllByUserId(userId).map { it.userId }.toSet() // 내가 차단한 유저
+        val blockedMeUserIds = blockContactListService.findAllByPhoneNumber(
+            user.phoneNumber ?: throw IllegalStateException("핸드폰 번호를 등록해주세요")
+        ).map { it.userId }.toSet() // 나를 차단한 유저
 
         if (isActiveMatching) {
             val matchingHour = 18
@@ -98,7 +99,6 @@ class BottleFacade(
             randomBottles = randomBottles,
             sentBottles = sentBottles,
             nextBottleLeftHours = getNextBottleLeftHours(LocalDateTime.now())
-
         ).also {
             applicationEventPublisher.publishEvent(
                 UserApplicationEventDto(
@@ -128,7 +128,10 @@ class BottleFacade(
             keyword = bottle.sourceUser.userProfile?.profileSelect?.keyword,
             userImageUrl = bottle.sourceUser.userProfile?.blurredImageUrl,
             expiredAt = bottle.expiredAt,
-            lastActivatedAt = getLastActivatedAtInKorean(basedAt = bottle.sourceUser.lastActivatedAt, now = LocalDateTime.now())
+            lastActivatedAt = getLastActivatedAtInKorean(
+                basedAt = bottle.sourceUser.lastActivatedAt,
+                now = LocalDateTime.now()
+            )
         )
     }
 
@@ -186,25 +189,26 @@ class BottleFacade(
         val reportUserIds = userReportService.getReportRespondentList(userId)
             .map { it.respondentUserId }
             .toSet()
-        val blockUserIds = blockContactListService.findAllByUserId(userId).map{ it.userId }.toSet() // 내가 차단한 유저
-        val blockMeUserIds = blockContactListService.findAllByPhoneNumber(user.phoneNumber ?: throw IllegalStateException("핸드폰 번호를 등록해주세요"))
-            .map{ it.userId }.toSet() // 나를 차단한 유저
+        val blockUserIds = blockContactListService.findAllByUserId(userId).map { it.userId }.toSet() // 내가 차단한 유저
+        val blockMeUserIds = blockContactListService.findAllByPhoneNumber(
+            user.phoneNumber ?: throw IllegalStateException("핸드폰 번호를 등록해주세요")
+        ).map { it.userId }.toSet() // 나를 차단한 유저
 
         val activeBottles = groupByStatus[PingPongStatus.ACTIVE]
             ?.map { toPingPongBottleDto(it, user) }
             ?.filter { it.userId !in reportUserIds }
-            ?.filter { it.userId !in blockUserIds}
+            ?.filter { it.userId !in blockUserIds }
             ?.filter { it.userId !in blockMeUserIds }
             ?: emptyList()
         val doneBottles =
             (groupByStatus[PingPongStatus.STOPPED]
                 .orEmpty()
                 .filter { it.isNotExpiredAfterStopped(LocalDateTime.now()) } +
-             groupByStatus[PingPongStatus.MATCHED].orEmpty()
-            )
+                    groupByStatus[PingPongStatus.MATCHED].orEmpty()
+                    )
                 .map { toPingPongBottleDto(it, user) }
                 .filter { it.userId !in reportUserIds }
-                .filter { it.userId !in blockUserIds}
+                .filter { it.userId !in blockUserIds }
                 .filter { it.userId !in blockMeUserIds }
         return PingPongListResponse(activeBottles = activeBottles, doneBottles = doneBottles)
     }
@@ -222,7 +226,10 @@ class BottleFacade(
             mbti = otherUser.userProfile?.profileSelect?.mbti,
             keyword = otherUser.userProfile?.profileSelect?.keyword,
             userImageUrl = otherUser.userProfile?.blurredImageUrl,
-            lastActivatedAt = getLastActivatedAtInKorean(basedAt = otherUser.lastActivatedAt, now = LocalDateTime.now()),
+            lastActivatedAt = getLastActivatedAtInKorean(
+                basedAt = otherUser.lastActivatedAt,
+                now = LocalDateTime.now()
+            ),
         )
     }
 
@@ -299,7 +306,12 @@ class BottleFacade(
                 meetingPlaceImageUrl = null,
             )
         ).also {
-            applicationEventPublisher.publishEvent(UserApplicationEventDto(userId = userId, basedAt = LocalDateTime.now()))
+            applicationEventPublisher.publishEvent(
+                UserApplicationEventDto(
+                    userId = userId,
+                    basedAt = LocalDateTime.now()
+                )
+            )
         }
     }
 

--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacadeV2.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacadeV2.kt
@@ -1,0 +1,142 @@
+package com.nexters.bottles.api.bottle.facade
+
+import com.nexters.bottles.api.bottle.event.dto.BottleMatchEventDto
+import com.nexters.bottles.api.bottle.facade.dto.RandomBottleDto
+import com.nexters.bottles.api.bottle.facade.dto.RandomBottleListResponse
+import com.nexters.bottles.api.bottle.facade.dto.SentBottleDto
+import com.nexters.bottles.api.bottle.facade.dto.SentBottleListResponse
+import com.nexters.bottles.api.bottle.util.getLastActivatedAtInKorean
+import com.nexters.bottles.api.user.component.event.dto.UserApplicationEventDto
+import com.nexters.bottles.app.bottle.domain.Bottle
+import com.nexters.bottles.app.bottle.domain.enum.BottleStatus
+import com.nexters.bottles.app.bottle.service.BottleService
+import com.nexters.bottles.app.user.domain.User
+import com.nexters.bottles.app.user.service.BlockContactListService
+import com.nexters.bottles.app.user.service.UserReportService
+import com.nexters.bottles.app.user.service.UserService
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+@Component
+class BottleFacadeV2(
+    private val bottleService: BottleService,
+    private val userService: UserService,
+    private val userReportService: UserReportService,
+    private val blockContactListService: BlockContactListService,
+    private val applicationEventPublisher: ApplicationEventPublisher,
+) {
+
+    fun getRandomBottles(userId: Long): RandomBottleListResponse {
+        val user = userService.findByIdAndNotDeleted(userId)
+        val blockUserIds = blockContactListService.findAllByUserId(userId).map { it.userId }.toSet() // 내가 차단한 유저
+        val blockedMeUserIds = blockContactListService.findAllByPhoneNumber(
+            user.phoneNumber ?: throw IllegalStateException("핸드폰 번호를 등록해주세요")
+        ).map { it.userId }.toSet() // 나를 차단한 유저
+
+        val matchingHour = 18
+        bottleService.matchRandomBottle(user, matchingHour, blockUserIds, blockedMeUserIds)
+            ?.also {
+                applicationEventPublisher.publishEvent(
+                    BottleMatchEventDto(
+                        sourceUserId = it.sourceUser.id,
+                        targetUserId = it.targetUser.id,
+                    )
+                )
+            }
+
+        val bottles = bottleService.getNewBottlesByBottleStatus(user, setOf(BottleStatus.RANDOM))
+        val randomBottles = bottles.map { toRandomBottleDto(it, userId) }
+
+        return RandomBottleListResponse(
+            randomBottles = randomBottles,
+            nextBottleLeftHours = getNextBottleLeftHours(LocalDateTime.now())
+        ).also {
+            publishUserApplicationEvent(user)
+        }
+    }
+
+    private fun getNextBottleLeftHours(now: LocalDateTime): Int {
+        return if (now.toLocalTime() > LocalTime.of(18, 0)) {
+            18 + (LocalTime.MAX.hour - now.hour)
+        } else {
+            LocalTime.of(18, 0).hour - now.hour
+        }
+    }
+
+    private fun toRandomBottleDto(bottle: Bottle, userId: Long): RandomBottleDto {
+        return RandomBottleDto(
+            id = bottle.id,
+            userId = bottle.findOtherUserId(userId = userId),
+            userName = bottle.sourceUser.getMaskedName(),
+            age = bottle.sourceUser.getKoreanAge(),
+            mbti = bottle.sourceUser.userProfile?.profileSelect?.mbti,
+            keyword = bottle.sourceUser.userProfile?.profileSelect?.keyword,
+            userImageUrl = bottle.sourceUser.userProfile?.blurredImageUrl,
+            expiredAt = bottle.expiredAt,
+            lastActivatedAt = getLastActivatedAtInKorean(
+                basedAt = bottle.sourceUser.lastActivatedAt,
+                now = LocalDateTime.now()
+            )
+        )
+    }
+
+    fun getSentBottles(userId: Long): SentBottleListResponse {
+        val user = userService.findByIdAndNotDeleted(userId)
+        val bottles = bottleService.getNewBottlesByBottleStatus(user, setOf(BottleStatus.SENT))
+
+        if (bottles.isEmpty()) {
+            return SentBottleListResponse(
+                sentBottles = emptyList()
+            ).also {
+                publishUserApplicationEvent(user)
+            }
+        }
+
+        val blockUserIds = blockContactListService.findAllByUserId(userId).map { it.userId }.toSet() // 내가 차단한 유저
+        val blockedMeUserIds = blockContactListService.findAllByPhoneNumber(
+            user.phoneNumber ?: throw IllegalStateException("핸드폰 번호를 등록해주세요")
+        ).map { it.userId }.toSet() // 나를 차단한 유저
+        val reportUserIds = userReportService.getReportRespondentList(userId)
+            .map { it.respondentUserId }
+            .toSet()
+
+        val sentBottles = bottles.map { toSentBottleDto(it, userId) }
+            .filter { it.userId !in reportUserIds }
+            .filter { it.userId !in blockUserIds }
+            .filter { it.userId !in blockedMeUserIds }
+
+        return SentBottleListResponse(
+            sentBottles = sentBottles
+        ).also {
+            publishUserApplicationEvent(user)
+        }
+    }
+
+    private fun toSentBottleDto(bottle: Bottle, userId: Long): SentBottleDto {
+        return SentBottleDto(
+            id = bottle.id,
+            userId = bottle.findOtherUserId(userId = userId),
+            userName = bottle.sourceUser.getMaskedName(),
+            age = bottle.sourceUser.getKoreanAge(),
+            mbti = bottle.sourceUser.userProfile?.profileSelect?.mbti,
+            keyword = bottle.sourceUser.userProfile?.profileSelect?.keyword,
+            userImageUrl = bottle.sourceUser.userProfile?.blurredImageUrl,
+            expiredAt = bottle.expiredAt,
+            lastActivatedAt = getLastActivatedAtInKorean(
+                basedAt = bottle.sourceUser.lastActivatedAt,
+                now = LocalDateTime.now()
+            )
+        )
+    }
+
+    private fun publishUserApplicationEvent(user: User) {
+        applicationEventPublisher.publishEvent(
+            UserApplicationEventDto(
+                userId = user.id,
+                basedAt = LocalDateTime.now(),
+            )
+        )
+    }
+}

--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/dto/RandomBottleListResponse.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/dto/RandomBottleListResponse.kt
@@ -1,0 +1,23 @@
+package com.nexters.bottles.api.bottle.facade.dto
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import java.time.LocalDateTime
+
+data class RandomBottleListResponse(
+    val randomBottles: List<RandomBottleDto>,
+    val nextBottleLeftHours: Int,
+)
+
+data class RandomBottleDto(
+    val id: Long,
+    val userId: Long,
+    val userName: String?,
+    val age: Int,
+    val mbti: String?,
+    val keyword: List<String>?,
+    val userImageUrl: String?,
+    val lastActivatedAt: String?,
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    val expiredAt: LocalDateTime
+)

--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/dto/SentBottleListResponse.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/dto/SentBottleListResponse.kt
@@ -1,0 +1,22 @@
+package com.nexters.bottles.api.bottle.facade.dto
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import java.time.LocalDateTime
+
+data class SentBottleListResponse(
+    val sentBottles: List<SentBottleDto>,
+)
+
+data class SentBottleDto(
+    val id: Long,
+    val userId: Long,
+    val userName: String?,
+    val age: Int,
+    val mbti: String?,
+    val keyword: List<String>?,
+    val userImageUrl: String?,
+    val lastActivatedAt: String?,
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    val expiredAt: LocalDateTime
+)

--- a/api/src/main/kotlin/com/nexters/bottles/api/user/component/event/UserApplicationEventListener.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/user/component/event/UserApplicationEventListener.kt
@@ -2,7 +2,6 @@ package com.nexters.bottles.api.user.component.event
 
 import com.nexters.bottles.api.user.component.event.dto.UserApplicationEventDto
 import com.nexters.bottles.app.user.service.UserService
-import mu.KotlinLogging
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
@@ -11,9 +10,7 @@ import org.springframework.stereotype.Component
 class UserApplicationEventListener(
     private val userService: UserService,
 ) {
-
-    private val log = KotlinLogging.logger { }
-
+    
     @Async
     @EventListener
     fun handleCustomEvent(event: UserApplicationEventDto) {

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/repository/BottleRepository.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/repository/BottleRepository.kt
@@ -1,6 +1,7 @@
 package com.nexters.bottles.app.bottle.repository
 
 import com.nexters.bottles.app.bottle.domain.Bottle
+import com.nexters.bottles.app.bottle.domain.enum.BottleStatus
 import com.nexters.bottles.app.bottle.domain.enum.PingPongStatus
 import com.nexters.bottles.app.user.domain.User
 import org.springframework.data.jpa.repository.JpaRepository
@@ -19,6 +20,17 @@ interface BottleRepository : JpaRepository<Bottle, Long> {
     fun findAllByTargetUserAndStatusAndNotExpiredAndDeletedFalse(
         @Param("targetUser") targetUser: User,
         @Param("pingPongStatus") pingPongStatus: PingPongStatus,
+        @Param("currentDateTime") currentDateTime: LocalDateTime
+    ): List<Bottle>
+
+    @Query(
+        value = "SELECT b FROM Bottle b " +
+                "WHERE b.targetUser = :targetUser AND b.expiredAt > :currentDateTime AND b.bottleStatus IN :bottleStatus " +
+                "AND b.deleted = false AND b.targetUser.deleted = false AND b.sourceUser.deleted = false "
+    )
+    fun findAllByTargetUserAndBottleStatusAndNotExpiredAndDeletedFalse(
+        @Param("targetUser") targetUser: User,
+        @Param("bottleStatus") bottleStatus: Set<BottleStatus>,
         @Param("currentDateTime") currentDateTime: LocalDateTime
     ): List<Bottle>
 

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleService.kt
@@ -27,13 +27,20 @@ class BottleService(
     private val bottleMatchingRepository: BottleMatchingRepository,
 ) {
 
-    private val log = KotlinLogging.logger {}
-
     @Transactional(readOnly = true)
     fun getNewBottles(user: User): List<Bottle> {
         return bottleRepository.findAllByTargetUserAndStatusAndNotExpiredAndDeletedFalse(
             user,
             PingPongStatus.NONE,
+            LocalDateTime.now()
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun getNewBottlesByBottleStatus(user: User, statusSet: Set<BottleStatus>): List<Bottle> {
+        return bottleRepository.findAllByTargetUserAndBottleStatusAndNotExpiredAndDeletedFalse(
+            user,
+            statusSet,
             LocalDateTime.now()
         )
     }
@@ -154,7 +161,12 @@ class BottleService(
     }
 
     @Transactional
-    fun matchRandomBottle(user: User, matchingHour: Int, blockUserIds: Set<Long>, blockedMeUserIds: Set<Long>): Bottle? {
+    fun matchRandomBottle(
+        user: User,
+        matchingHour: Int,
+        blockUserIds: Set<Long>,
+        blockedMeUserIds: Set<Long>
+    ): Bottle? {
         if (user.isNotRegisterProfile()) return null
         if (user.isMatchInactive()) return null
 


### PR DESCRIPTION
## 💡 이슈 번호
close: #445 

## ✨ 작업 내용
- 홈(모래사장)에서 랜덤 보틀과 호감을 받은 보틀을 함께 보여주던 것을 모래사장/호감 탭 분리에 따라 API를 분리했습니다.

## 🚀 전달 사항
- 문답 탭은 기존 보틀보관함 조회 API를 사용하면 될 것 같아서 추가하지 않았습니다.