### PR TITLE
[Feature/465] 추천 보틀, 호감 보틀 조회 API 응답값을 추가한다

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacade.kt
@@ -148,7 +148,7 @@ class BottleFacade(
             age = bottle.sourceUser.getKoreanAge(),
             introduction = bottle.sourceUser.userProfile?.introduction,
             profileSelect = bottle.sourceUser.userProfile?.profileSelect,
-            likeMessage = bottle.likeMessage,
+            likeMessage = bottle.likeMessage?.value,
             userImageUrl = bottle.sourceUser.userProfile?.blurredImageUrl
         )
     }

--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacadeV2.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacadeV2.kt
@@ -71,6 +71,7 @@ class BottleFacadeV2(
             userId = bottle.findOtherUserId(userId = userId),
             userName = bottle.sourceUser.getMaskedName(),
             age = bottle.sourceUser.getKoreanAge(),
+            introduction = bottle.sourceUser.userProfile?.introduction,
             mbti = bottle.sourceUser.userProfile?.profileSelect?.mbti,
             keyword = bottle.sourceUser.userProfile?.profileSelect?.keyword,
             userImageUrl = bottle.sourceUser.userProfile?.blurredImageUrl,
@@ -120,8 +121,10 @@ class BottleFacadeV2(
             userId = bottle.findOtherUserId(userId = userId),
             userName = bottle.sourceUser.getMaskedName(),
             age = bottle.sourceUser.getKoreanAge(),
+            introduction = bottle.sourceUser.userProfile?.introduction,
             mbti = bottle.sourceUser.userProfile?.profileSelect?.mbti,
             keyword = bottle.sourceUser.userProfile?.profileSelect?.keyword,
+            likeEmoji = bottle.likeMessage?.getLikeEmoji(),
             userImageUrl = bottle.sourceUser.userProfile?.blurredImageUrl,
             expiredAt = bottle.expiredAt,
             lastActivatedAt = getLastActivatedAtInKorean(

--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/dto/RandomBottleListResponse.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/dto/RandomBottleListResponse.kt
@@ -1,6 +1,7 @@
 package com.nexters.bottles.api.bottle.facade.dto
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import com.nexters.bottles.app.user.domain.QuestionAndAnswer
 import java.time.LocalDateTime
 
 data class RandomBottleListResponse(
@@ -13,6 +14,7 @@ data class RandomBottleDto(
     val userId: Long,
     val userName: String?,
     val age: Int,
+    val introduction: List<QuestionAndAnswer>? = null,
     val mbti: String?,
     val keyword: List<String>?,
     val userImageUrl: String?,

--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/dto/SentBottleListResponse.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/dto/SentBottleListResponse.kt
@@ -1,6 +1,7 @@
 package com.nexters.bottles.api.bottle.facade.dto
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import com.nexters.bottles.app.user.domain.QuestionAndAnswer
 import java.time.LocalDateTime
 
 data class SentBottleListResponse(
@@ -12,8 +13,10 @@ data class SentBottleDto(
     val userId: Long,
     val userName: String?,
     val age: Int,
+    val introduction: List<QuestionAndAnswer>? = null,
     val mbti: String?,
     val keyword: List<String>?,
+    val likeEmoji: String?,
     val userImageUrl: String?,
     val lastActivatedAt: String?,
 

--- a/app/src/main/kotlin/com/nexters/bottles/app/admin/service/AdminService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/admin/service/AdminService.kt
@@ -6,6 +6,7 @@ import com.nexters.bottles.app.auth.repository.BlackListRepository
 import com.nexters.bottles.app.auth.repository.RefreshTokenRepository
 import com.nexters.bottles.app.bottle.domain.Bottle
 import com.nexters.bottles.app.bottle.domain.enum.BottleStatus
+import com.nexters.bottles.app.bottle.domain.vo.LikeMessage
 import com.nexters.bottles.app.bottle.repository.BottleRepository
 import com.nexters.bottles.app.bottle.repository.LetterRepository
 import com.nexters.bottles.app.user.domain.User
@@ -84,7 +85,7 @@ class AdminService(
                 targetUser = mockMaleUser,
                 sourceUser = mockFemaleUser,
                 bottleStatus = bottleStatus,
-                likeMessage = likeMessage,
+                likeMessage = LikeMessage(likeMessage!!),
             )
         )
     }

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/domain/Bottle.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/domain/Bottle.kt
@@ -2,10 +2,12 @@ package com.nexters.bottles.app.bottle.domain
 
 import com.nexters.bottles.app.bottle.domain.enum.BottleStatus
 import com.nexters.bottles.app.bottle.domain.enum.PingPongStatus
+import com.nexters.bottles.app.bottle.domain.vo.LikeMessage
 import com.nexters.bottles.app.common.BaseEntity
 import com.nexters.bottles.app.user.domain.User
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
+import javax.persistence.Embedded
 import javax.persistence.Entity
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
@@ -30,7 +32,8 @@ class Bottle(
     @JoinColumn(name = "source_user_id")
     var sourceUser: User,
 
-    var likeMessage: String? = null,
+    @Embedded
+    var likeMessage: LikeMessage? = null,
 
     var expiredAt: LocalDateTime = LocalDateTime.now().plusDays(1),
 
@@ -58,7 +61,7 @@ class Bottle(
     fun sendLikeMessage(from: User, to: User, likeMessage: String, now: LocalDateTime) {
         this.targetUser = to
         this.sourceUser = from
-        this.likeMessage = likeMessage
+        this.likeMessage = LikeMessage(likeMessage)
         this.bottleStatus = BottleStatus.SENT
         this.expiredAt = now.plusDays(1)
     }

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/domain/vo/LikeMessage.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/domain/vo/LikeMessage.kt
@@ -1,0 +1,23 @@
+package com.nexters.bottles.app.bottle.domain.vo
+
+import java.util.regex.Pattern
+import javax.persistence.Embeddable
+
+@Embeddable
+class LikeMessage(
+    val value: String
+) {
+
+    fun getLikeEmoji(): String {
+        val emojiPattern = Pattern.compile(
+            "[\\p{So}\\p{Cn}\\p{Sc}\\p{Sk}\\p{Sm}\\p{Zs}]",
+            Pattern.UNICODE_CHARACTER_CLASS
+        )
+        val matcher = emojiPattern.matcher(this.value)
+
+        return matcher.results()
+            .map { it.group() }
+            .toList()
+            .lastOrNull() ?: throw IllegalStateException("이모지를 찾을 수 없습니다.")
+    }
+}

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/domain/vo/LikeMessage.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/domain/vo/LikeMessage.kt
@@ -9,15 +9,18 @@ class LikeMessage(
 ) {
 
     fun getLikeEmoji(): String {
-        val emojiPattern = Pattern.compile(
-            "[\\p{So}\\p{Cn}\\p{Sc}\\p{Sk}\\p{Sm}\\p{Zs}]",
-            Pattern.UNICODE_CHARACTER_CLASS
-        )
-        val matcher = emojiPattern.matcher(this.value)
+        val matcher = EMOJI_PATTERN.matcher(this.value)
 
         return matcher.results()
             .map { it.group() }
             .toList()
             .lastOrNull() ?: throw IllegalStateException("이모지를 찾을 수 없습니다.")
+    }
+
+    companion object {
+        private val EMOJI_PATTERN = Pattern.compile(
+            "[\\p{So}\\p{Cn}\\p{Sc}\\p{Sk}\\p{Sm}\\p{Zs}]",
+            Pattern.UNICODE_CHARACTER_CLASS
+        )
     }
 }

--- a/app/src/test/kotlin/com/nexters/bottles/app/bottle/domain/vo/LikeMessageTest.kt
+++ b/app/src/test/kotlin/com/nexters/bottles/app/bottle/domain/vo/LikeMessageTest.kt
@@ -1,0 +1,23 @@
+package com.nexters.bottles.app.bottle.domain.vo
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class LikeMessageTest {
+
+    @ParameterizedTest
+    @CsvSource(
+        "반가워요 🥰,🥰",
+        "반가워요 🥳,🥳",
+        "반가워요 😉,😉",
+        "반가워요 😎,😎",
+        "반가🥰워요 😎,😎",
+    )
+    fun `호감 메세지에서 가장 마지막 이모티콘을 파싱한다`(input: String, expected: String) {
+        val likeMessage = LikeMessage(input)
+        val likeEmoji = likeMessage.getLikeEmoji()
+
+        assertThat(likeEmoji).isEqualTo(expected)
+    }
+}


### PR DESCRIPTION
## 💡 이슈 번호
close: #465 

## ✨ 작업 내용
- 추천 보틀, 호감 보틀 조회 API 응답값을 추가했습니다.

## 🚀 전달 사항
- Bottle의 likeMessage를 VO로 변경했어요!