### PR TITLE
[Fix/487] 거절된 보틀 조회되지 않도록 수정 및 정렬 조건을 추가한다

### DIFF
--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/repository/BottleRepository.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/repository/BottleRepository.kt
@@ -25,12 +25,14 @@ interface BottleRepository : JpaRepository<Bottle, Long> {
 
     @Query(
         value = "SELECT b FROM Bottle b " +
-                "WHERE b.targetUser = :targetUser AND b.expiredAt > :currentDateTime AND b.bottleStatus IN :bottleStatus " +
-                "AND b.deleted = false AND b.targetUser.deleted = false AND b.sourceUser.deleted = false "
+                "WHERE b.targetUser = :targetUser AND b.expiredAt > :currentDateTime AND b.bottleStatus IN :bottleStatus AND b.pingPongStatus IN :pingpPongStatus " +
+                "AND b.deleted = false AND b.targetUser.deleted = false AND b.sourceUser.deleted = false " +
+                "ORDER BY b.createdAt desc "
     )
-    fun findAllByTargetUserAndBottleStatusAndNotExpiredAndDeletedFalse(
+    fun findAllByTargetUserAndStatusesAndNotExpiredAndDeletedFalseOrderByCreatedDesc(
         @Param("targetUser") targetUser: User,
         @Param("bottleStatus") bottleStatus: Set<BottleStatus>,
+        @Param("pingPongStatus") pingPongStatus: Set<PingPongStatus>,
         @Param("currentDateTime") currentDateTime: LocalDateTime
     ): List<Bottle>
 

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleService.kt
@@ -12,7 +12,6 @@ import com.nexters.bottles.app.bottle.repository.LetterRepository
 import com.nexters.bottles.app.bottle.repository.dto.UsersCanBeMatchedDto
 import com.nexters.bottles.app.user.domain.User
 import com.nexters.bottles.app.user.repository.UserRepository
-import mu.KotlinLogging
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -38,9 +37,10 @@ class BottleService(
 
     @Transactional(readOnly = true)
     fun getNewBottlesByBottleStatus(user: User, statusSet: Set<BottleStatus>): List<Bottle> {
-        return bottleRepository.findAllByTargetUserAndBottleStatusAndNotExpiredAndDeletedFalse(
+        return bottleRepository.findAllByTargetUserAndStatusesAndNotExpiredAndDeletedFalseOrderByCreatedDesc(
             user,
             statusSet,
+            setOf(PingPongStatus.NONE),
             LocalDateTime.now()
         )
     }


### PR DESCRIPTION
## 💡 이슈 번호
close: #487 

## ✨ 작업 내용
- 거절된 보틀 조회되지 않도록 수정 및 `created_at desc` 정렬 조건을 추가했습니다.

## 🚀 전달 사항
