### PR TITLE
[Feature/500] 로컬에서는 실행되지 않게 만들기

### DIFF
--- a/app/src/main/kotlin/com/nexters/bottles/app/common/annotation/LiveOnly.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/common/annotation/LiveOnly.kt
@@ -1,0 +1,5 @@
+package com.nexters.bottles.app.common.annotation
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class LiveOnly

--- a/app/src/main/kotlin/com/nexters/bottles/app/common/aspect/LiveOnlyAspect.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/common/aspect/LiveOnlyAspect.kt
@@ -1,0 +1,27 @@
+package com.nexters.bottles.app.common.aspect
+
+import mu.KotlinLogging
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.springframework.core.env.Environment
+import org.springframework.stereotype.Component
+
+@Aspect
+@Component
+class LiveOnlyAspect(
+    private val environment: Environment,
+) {
+
+    private val log = KotlinLogging.logger {}
+
+    @Around("@annotation(com.nexters.bottles.app.common.annotation.LiveOnly)")
+    fun devOnlyMethod(joinPoint: ProceedingJoinPoint): Any? {
+        return if (environment.activeProfiles.any { it == "dev" || it == "live" }) {
+            joinPoint.proceed()
+        } else {
+            log.info { "LiveOnly여서 로컬에서 실행되지 않음" }
+            null
+        }
+    }
+}

--- a/app/src/main/kotlin/com/nexters/bottles/app/notification/component/StatisticsScheduler.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/notification/component/StatisticsScheduler.kt
@@ -3,6 +3,7 @@ package com.nexters.bottles.app.notification.component
 import com.nexters.bottles.app.bottle.domain.enum.PingPongStatus
 import com.nexters.bottles.app.bottle.repository.BottleRepository
 import com.nexters.bottles.app.bottle.repository.LetterRepository
+import com.nexters.bottles.app.common.annotation.LiveOnly
 import com.nexters.bottles.app.user.domain.enum.Gender
 import com.nexters.bottles.app.user.repository.UserProfileRepository
 import com.nexters.bottles.app.user.repository.UserRepository
@@ -38,7 +39,8 @@ class StatisticsScheduler(
         .baseUrl(slackUrl)
         .build()
 
-    @Scheduled(cron = "0 30 10 * * *")
+    @LiveOnly
+    @Scheduled(cron = "0 0 10 * * *")
     fun sendDailyStatistics() {
         val yesterday = LocalDate.now().minusDays(1)
 
@@ -91,6 +93,7 @@ class StatisticsScheduler(
             .block()
     }
 
+    @LiveOnly
     @Scheduled(cron = "0 30 10 * * 1")
     fun sendWeeklyStatistics() {
         val lastWeekMonday = LocalDate.now().minusDays(7)


### PR DESCRIPTION
## 💡 이슈 번호
close: #500 

## ✨ 작업 내용
로컬에서는 실행되지 않게 만들기

## 🚀 전달 사항
실제로 회사에서도 운영 환경마다 실행되어야하는 혹은 안되어야하는 것들을 분리할 니즈가 있더라고요. 그래서 라이브 환경에서는 빈 등록이 안되게 하기도하고, 이번 pr처럼 메서드가 실행이 안되게도 합니다. 

1. 지금처럼 어노테이션을 이용한 AOP
2. 코틀린 DSL을 정의해서 이용

1번의 경우 직관적이지만 AOP를 이용하니 self invocation 방지 때문에 괜히 다른 클래스로 분리해야 할때도 있고 그런 번거로움이 있긴하더라고요. 그래서 2번이 좋나? 요즘 고민이 되네요 ㅎㅎ 미성님 의견은 어떤가요