### PR TITLE
[Feature/468] 문답 목록 조회 api v2를 구현한다

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/controller/BottleControllerV2.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/controller/BottleControllerV2.kt
@@ -1,6 +1,7 @@
 package com.nexters.bottles.api.bottle.controller
 
 import com.nexters.bottles.api.bottle.facade.BottleFacadeV2
+import com.nexters.bottles.api.bottle.facade.dto.PingPongListResponseV2
 import com.nexters.bottles.api.bottle.facade.dto.RandomBottleListResponse
 import com.nexters.bottles.api.bottle.facade.dto.SentBottleListResponse
 import com.nexters.bottles.api.global.interceptor.AuthRequired
@@ -28,5 +29,12 @@ class BottleControllerV2(
     @AuthRequired
     fun getSentBottlesList(@AuthUserId userId: Long): SentBottleListResponse {
         return bottleFacadeV2.getSentBottles(userId)
+    }
+
+    @ApiOperation("문답 - 핑퐁중인 보틀 목록 조회하기")
+    @GetMapping("/ping-pong")
+    @AuthRequired
+    fun getPingPongList(@AuthUserId userId: Long): PingPongListResponseV2 {
+        return bottleFacadeV2.getPingPongBottles(userId)
     }
 }

--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacadeV2.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/BottleFacadeV2.kt
@@ -1,6 +1,8 @@
 package com.nexters.bottles.api.bottle.facade
 
 import com.nexters.bottles.api.bottle.event.dto.BottleMatchEventDto
+import com.nexters.bottles.api.bottle.facade.dto.PingPongBottleDtoV2
+import com.nexters.bottles.api.bottle.facade.dto.PingPongListResponseV2
 import com.nexters.bottles.api.bottle.facade.dto.RandomBottleDto
 import com.nexters.bottles.api.bottle.facade.dto.RandomBottleListResponse
 import com.nexters.bottles.api.bottle.facade.dto.SentBottleDto
@@ -9,7 +11,9 @@ import com.nexters.bottles.api.bottle.util.getLastActivatedAtInKorean
 import com.nexters.bottles.api.user.component.event.dto.UserApplicationEventDto
 import com.nexters.bottles.app.bottle.domain.Bottle
 import com.nexters.bottles.app.bottle.domain.enum.BottleStatus
+import com.nexters.bottles.app.bottle.service.BottleCachingService
 import com.nexters.bottles.app.bottle.service.BottleService
+import com.nexters.bottles.app.bottle.service.LetterService
 import com.nexters.bottles.app.user.domain.User
 import com.nexters.bottles.app.user.service.BlockContactListService
 import com.nexters.bottles.app.user.service.UserReportService
@@ -25,6 +29,8 @@ class BottleFacadeV2(
     private val userService: UserService,
     private val userReportService: UserReportService,
     private val blockContactListService: BlockContactListService,
+    private val letterService: LetterService,
+    private val bottleCachingService: BottleCachingService,
     private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
 
@@ -140,6 +146,48 @@ class BottleFacadeV2(
                 userId = user.id,
                 basedAt = LocalDateTime.now(),
             )
+        )
+    }
+
+    fun getPingPongBottles(userId: Long): PingPongListResponseV2 {
+        val user = userService.findByIdAndNotDeleted(userId)
+        val pingPongBottles = bottleCachingService.getPingPongBottlesV2(userId)
+        val reportUserIds = userReportService.getReportRespondentList(userId)
+            .map { it.respondentUserId }
+            .toSet()
+        val blockUserIds = blockContactListService.findAllByUserId(userId).map { it.userId }.toSet() // 내가 차단한 유저
+        val blockMeUserIds = blockContactListService.findAllByPhoneNumber(
+            user.phoneNumber ?: throw IllegalStateException("핸드폰 번호를 등록해주세요")
+        ).map { it.userId }.toSet() // 나를 차단한 유저
+
+        return PingPongListResponseV2(
+            pingPongBottles = pingPongBottles.filter { it.findOtherUserId(user.id) !in reportUserIds }
+                .filter { it.findOtherUserId(user.id) !in blockUserIds }
+                .filter { it.findOtherUserId(user.id) !in blockMeUserIds }
+                .map { toPingPongBottleDto(it, user) }
+        )
+    }
+
+    private fun toPingPongBottleDto(bottle: Bottle, user: User): PingPongBottleDtoV2 {
+        val otherUser = bottle.findOtherUser(user)
+        val otherUserLetter = letterService.findLetter(bottle, otherUser)
+        val lastStatus = letterService.findLastStatus(bottle, user, otherUser)
+        val lastUpdatedAt = letterService.findLastUpdated(bottle, user, otherUser)
+
+        return PingPongBottleDtoV2(
+            id = bottle.id,
+            isRead = otherUserLetter.isReadByOtherUser,
+            userName = otherUser.getMaskedName(),
+            userId = otherUser.id,
+            age = otherUser.getKoreanAge(),
+            mbti = otherUser.userProfile?.profileSelect?.mbti,
+            keyword = otherUser.userProfile?.profileSelect?.keyword,
+            userImageUrl = otherUser.userProfile?.blurredImageUrl,
+            lastActivatedAt = getLastActivatedAtInKorean(
+                basedAt = lastUpdatedAt,
+                now = LocalDateTime.now()
+            ),
+            lastStatus = lastStatus
         )
     }
 }

--- a/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/dto/PingPongListResponseV2.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/bottle/facade/dto/PingPongListResponseV2.kt
@@ -1,11 +1,12 @@
 package com.nexters.bottles.api.bottle.facade.dto
 
-data class PingPongListResponse(
-    val activeBottles: List<PingPongBottleDto>,
-    val doneBottles: List<PingPongBottleDto>
+import com.nexters.bottles.app.bottle.domain.enum.LetterLastStatus
+
+data class PingPongListResponseV2(
+    val pingPongBottles: List<PingPongBottleDtoV2>,
 )
 
-data class PingPongBottleDto(
+data class PingPongBottleDtoV2(
     val id: Long,
     val isRead: Boolean,
     val userName: String?,
@@ -15,4 +16,5 @@ data class PingPongBottleDto(
     val keyword: List<String>?,
     val userImageUrl: String?,
     val lastActivatedAt: String?,
+    val lastStatus: LetterLastStatus
 )

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/domain/Letter.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/domain/Letter.kt
@@ -1,5 +1,6 @@
 package com.nexters.bottles.app.bottle.domain
 
+import com.nexters.bottles.app.bottle.domain.enum.LetterLastStatus
 import com.nexters.bottles.app.bottle.repository.converter.LetterQuestionAndAnswerConverter
 import com.nexters.bottles.app.common.BaseEntity
 import com.nexters.bottles.app.user.domain.User
@@ -79,6 +80,33 @@ class Letter(
 
     fun notFinishedLastAnswer(): Boolean {
         return letters.last().answer == null
+    }
+
+    fun findLastStatusWithOtherLetter(otherLetter: Letter): LetterLastStatus {
+        return when {
+            bottle.isStopped() -> LetterLastStatus.CONVERSATION_STOPPED
+            this.isShareContact != null && otherLetter.isShareContact == null -> LetterLastStatus.CONTACT_SHARED_BY_ME_ONLY
+            otherLetter.isShareContact != null -> LetterLastStatus.CONTACT_SHARED_BY_OTHER
+            this.isShareImage != null && otherLetter.isShareImage == null -> LetterLastStatus.PHOTO_SHARED_BY_ME_ONLY
+            otherLetter.isShareImage != null -> LetterLastStatus.PHOTO_SHARED_BY_OTHER
+            this.letters.isEmpty() && otherLetter.letters.isEmpty() -> LetterLastStatus.NO_ANSWER_FROM_BOTH
+            this.findAnsweredSize() > otherLetter.findAnsweredSize() -> LetterLastStatus.ANSWER_FROM_ME_ONLY
+            otherLetter.findAnsweredSize() >= this.findAnsweredSize() -> LetterLastStatus.ANSWER_FROM_OTHER
+            else -> LetterLastStatus.NO_ANSWER_FROM_BOTH
+        }
+    }
+
+    fun findAnsweredSize(): Int {
+        return this.letters.count {
+            it.answer != null
+        }
+    }
+
+    fun findLastUpdatedWithOtherLetter(otherLetter: Letter): LocalDateTime {
+        return when {
+            this.updatedAt > otherLetter.updatedAt -> this.updatedAt
+            else -> otherLetter.updatedAt
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/domain/Letter.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/domain/Letter.kt
@@ -89,7 +89,7 @@ class Letter(
             otherLetter.isShareContact != null -> LetterLastStatus.CONTACT_SHARED_BY_OTHER
             this.isShareImage != null && otherLetter.isShareImage == null -> LetterLastStatus.PHOTO_SHARED_BY_ME_ONLY
             otherLetter.isShareImage != null -> LetterLastStatus.PHOTO_SHARED_BY_OTHER
-            this.letters.isEmpty() && otherLetter.letters.isEmpty() -> LetterLastStatus.NO_ANSWER_FROM_BOTH
+            this.findAnsweredSize() == 0 && otherLetter.findAnsweredSize() == 0 -> LetterLastStatus.NO_ANSWER_FROM_BOTH
             this.findAnsweredSize() > otherLetter.findAnsweredSize() -> LetterLastStatus.ANSWER_FROM_ME_ONLY
             otherLetter.findAnsweredSize() >= this.findAnsweredSize() -> LetterLastStatus.ANSWER_FROM_OTHER
             else -> LetterLastStatus.NO_ANSWER_FROM_BOTH

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/domain/enum/LetterLastStatus.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/domain/enum/LetterLastStatus.kt
@@ -1,0 +1,27 @@
+package com.nexters.bottles.app.bottle.domain.enum
+
+enum class LetterLastStatus {
+    // 대화는 시작했으나 두 사람 모두 문답을 작성하지 않았을 때
+    NO_ANSWER_FROM_BOTH,
+
+    //상대방이 새로운 문답을 작성했을 때
+    ANSWER_FROM_OTHER,
+
+    // 상대방이 사진을 공유했을 때
+    PHOTO_SHARED_BY_OTHER,
+
+    // 상대방이 연락처를 공유했을 때
+    CONTACT_SHARED_BY_OTHER,
+
+    // 내가 문답을 작성했을 때 (상대방은 작성X)
+    ANSWER_FROM_ME_ONLY,
+
+    // 내가 사진을 공유했을 때 (상대방은 공유X)
+    PHOTO_SHARED_BY_ME_ONLY,
+
+    // 내가 연락처를 공유했을 때 (상대방은 공유X)
+    CONTACT_SHARED_BY_ME_ONLY,
+
+    // 대화가 중단됐을 때
+    CONVERSATION_STOPPED
+}

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/repository/BottleRepository.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/repository/BottleRepository.kt
@@ -53,9 +53,10 @@ interface BottleRepository : JpaRepository<Bottle, Long> {
                 "AND b.targetUser.deleted = false " +
                 "AND b.sourceUser.deleted = false " +
                 "AND b.pingPongStatus IN :pingPongStatus " +
-                "AND b.deleted = false "
+                "AND b.deleted = false " +
+                "ORDER BY b.updatedAt desc "
     )
-    fun findAllByNotDeletedUserAndStatusAndDeletedFalse(
+    fun findAllByNotDeletedUserAndStatusAndDeletedFalseOrderByUpdatedAtDesc(
         @Param("user") user: User,
         @Param("pingPongStatus") pingPongStatus: Set<PingPongStatus>
     ): List<Bottle>

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleCachingService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleCachingService.kt
@@ -23,6 +23,11 @@ class BottleCachingService(
         return bottleService.getPingPongBottles(userId)
     }
 
+    @Cacheable(PING_PONG_BOTTLE_LIST, key = "#userId + '-v2'")
+    fun getPingPongBottlesV2(userId: Long): List<Bottle> {
+        return bottleService.getPingPongBottles(userId)
+    }
+
     @Caching(
         evict = [
             CacheEvict(PING_PONG_BOTTLE_LIST, key = "#sourceUserId"),

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleService.kt
@@ -138,7 +138,7 @@ class BottleService(
     @Transactional(readOnly = true)
     fun getPingPongBottles(userId: Long): List<Bottle> {
         val user = userRepository.findByIdAndDeletedFalse(userId) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
-        return bottleRepository.findAllByNotDeletedUserAndStatusAndDeletedFalse(
+        return bottleRepository.findAllByNotDeletedUserAndStatusAndDeletedFalseOrderByUpdatedAtDesc(
             user,
             setOf(
                 PingPongStatus.ACTIVE,

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/LetterService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/LetterService.kt
@@ -2,6 +2,7 @@ package com.nexters.bottles.app.bottle.service
 
 import com.nexters.bottles.app.bottle.domain.Bottle
 import com.nexters.bottles.app.bottle.domain.Letter
+import com.nexters.bottles.app.bottle.domain.enum.LetterLastStatus
 import com.nexters.bottles.app.bottle.repository.BottleRepository
 import com.nexters.bottles.app.bottle.repository.LetterRepository
 import com.nexters.bottles.app.user.domain.User
@@ -59,5 +60,25 @@ class LetterService(
         } else {
             letter.finishIfAllShare()
         }
+    }
+
+    @Transactional(readOnly = true)
+    fun findLastStatus(bottle: Bottle, user: User, otherUser: User): LetterLastStatus {
+        val myLetter =
+            letterRepository.findByBottleAndUser(bottle, user) ?: throw IllegalArgumentException("고객센터에 문의해주세요")
+        val otherLetter =
+            letterRepository.findByBottleAndUser(bottle, otherUser) ?: throw IllegalArgumentException("고객센터에 문의해주세요")
+
+        return myLetter.findLastStatusWithOtherLetter(otherLetter);
+    }
+
+    @Transactional(readOnly = true)
+    fun findLastUpdated(bottle: Bottle, user: User, otherUser: User): LocalDateTime {
+        val myLetter =
+            letterRepository.findByBottleAndUser(bottle, user) ?: throw IllegalArgumentException("고객센터에 문의해주세요")
+        val otherLetter =
+            letterRepository.findByBottleAndUser(bottle, otherUser) ?: throw IllegalArgumentException("고객센터에 문의해주세요")
+
+        return myLetter.findLastUpdatedWithOtherLetter(otherLetter);
     }
 }

--- a/app/src/test/kotlin/com/nexters/bottles/app/bottle/domain/LetterTest.kt
+++ b/app/src/test/kotlin/com/nexters/bottles/app/bottle/domain/LetterTest.kt
@@ -1,0 +1,152 @@
+package com.nexters.bottles.app.bottle.domain
+
+import com.nexters.bottles.app.bottle.domain.enum.BottleStatus
+import com.nexters.bottles.app.bottle.domain.enum.LetterLastStatus
+import com.nexters.bottles.app.bottle.domain.enum.PingPongStatus
+import com.nexters.bottles.app.bottle.domain.vo.LikeMessage
+import com.nexters.bottles.app.user.domain.User
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class LetterTest {
+
+    companion object {
+        private val TARGET_USER = User(name = "user1")
+        private val SOURCE_USER = User(name = "user2")
+        private val PING_PONG_BOTTLE = Bottle(
+            targetUser = TARGET_USER, sourceUser = SOURCE_USER, likeMessage = LikeMessage("hi"),
+            bottleStatus = BottleStatus.SENT, pingPongStatus = PingPongStatus.ACTIVE
+        );
+        private val MY_LETTERS = listOf(
+            LetterQuestionAndAnswer(question = "question1"),
+            LetterQuestionAndAnswer(question = "question2"),
+            LetterQuestionAndAnswer(question = "question3")
+        )
+        private val OTHER_LETTERS = listOf(
+            LetterQuestionAndAnswer(question = "question1"),
+            LetterQuestionAndAnswer(question = "question2"),
+            LetterQuestionAndAnswer(question = "question3")
+        )
+    }
+
+    @Nested
+    inner class `문답의 가장 마지막 상태를 반환한다` {
+
+        @Test
+        fun `대화는 시작했으나 두 사람 모두 문답을 작성하지 않았을 경우`() {
+            val myLetter = Letter(bottle = PING_PONG_BOTTLE, user = TARGET_USER, letters = MY_LETTERS)
+            val otherLetter = Letter(bottle = PING_PONG_BOTTLE, user = SOURCE_USER, letters = OTHER_LETTERS)
+
+            val lastStatus = myLetter.findLastStatusWithOtherLetter(otherLetter)
+
+            assertThat(lastStatus).isEqualTo(LetterLastStatus.NO_ANSWER_FROM_BOTH)
+        }
+
+        @Test
+        fun `내가 문답을 작성했을 경우`() {
+            val myLetter = Letter(bottle = PING_PONG_BOTTLE, user = TARGET_USER, letters = MY_LETTERS)
+            val otherLetter = Letter(bottle = PING_PONG_BOTTLE, user = SOURCE_USER, letters = OTHER_LETTERS)
+            myLetter.registerAnswer(1, "답변")
+
+            val lastStatus = myLetter.findLastStatusWithOtherLetter(otherLetter)
+
+            assertThat(lastStatus).isEqualTo(LetterLastStatus.ANSWER_FROM_ME_ONLY)
+        }
+
+        @Test
+        fun `상대방이 문답을 작성했을 경우`() {
+            val myLetter = Letter(bottle = PING_PONG_BOTTLE, user = TARGET_USER, letters = MY_LETTERS)
+            val otherLetter = Letter(bottle = PING_PONG_BOTTLE, user = SOURCE_USER, letters = OTHER_LETTERS)
+            otherLetter.registerAnswer(1, "답변")
+
+            val lastStatus = myLetter.findLastStatusWithOtherLetter(otherLetter)
+
+            assertThat(lastStatus).isEqualTo(LetterLastStatus.ANSWER_FROM_OTHER)
+        }
+
+        @Test
+        fun `내가 사진을 공유한 경우`() {
+            val myLetter =
+                Letter(bottle = PING_PONG_BOTTLE, user = TARGET_USER, letters = MY_LETTERS, isShareImage = true)
+            val otherLetter = Letter(bottle = PING_PONG_BOTTLE, user = SOURCE_USER, letters = OTHER_LETTERS)
+
+            val lastStatus = myLetter.findLastStatusWithOtherLetter(otherLetter)
+
+            assertThat(lastStatus).isEqualTo(LetterLastStatus.PHOTO_SHARED_BY_ME_ONLY)
+        }
+
+        @Test
+        fun `상대방이 사진을 공유한 경우`() {
+            val myLetter = Letter(bottle = PING_PONG_BOTTLE, user = TARGET_USER, letters = MY_LETTERS)
+            val otherLetter =
+                Letter(bottle = PING_PONG_BOTTLE, user = SOURCE_USER, letters = OTHER_LETTERS, isShareImage = true)
+
+            val lastStatus = myLetter.findLastStatusWithOtherLetter(otherLetter)
+
+            assertThat(lastStatus).isEqualTo(LetterLastStatus.PHOTO_SHARED_BY_OTHER)
+        }
+
+        @Test
+        fun `둘 다 사진을 공유한 경우`() {
+            val myLetter =
+                Letter(bottle = PING_PONG_BOTTLE, user = TARGET_USER, letters = MY_LETTERS, isShareImage = true)
+            val otherLetter =
+                Letter(bottle = PING_PONG_BOTTLE, user = SOURCE_USER, letters = OTHER_LETTERS, isShareImage = true)
+
+            val lastStatus = myLetter.findLastStatusWithOtherLetter(otherLetter)
+
+            assertThat(lastStatus).isEqualTo(LetterLastStatus.PHOTO_SHARED_BY_OTHER)
+        }
+
+        @Test
+        fun `내가 연락처를 공유한 경우`() {
+            val myLetter =
+                Letter(bottle = PING_PONG_BOTTLE, user = TARGET_USER, letters = MY_LETTERS, isShareContact = true)
+            val otherLetter = Letter(bottle = PING_PONG_BOTTLE, user = SOURCE_USER, letters = OTHER_LETTERS)
+
+            val lastStatus = myLetter.findLastStatusWithOtherLetter(otherLetter)
+
+            assertThat(lastStatus).isEqualTo(LetterLastStatus.CONTACT_SHARED_BY_ME_ONLY)
+        }
+
+        @Test
+        fun `상대방이 연락처를 공유한 경우`() {
+            val myLetter = Letter(bottle = PING_PONG_BOTTLE, user = TARGET_USER, letters = MY_LETTERS)
+            val otherLetter =
+                Letter(bottle = PING_PONG_BOTTLE, user = SOURCE_USER, letters = OTHER_LETTERS, isShareContact = true)
+
+            val lastStatus = myLetter.findLastStatusWithOtherLetter(otherLetter)
+
+            assertThat(lastStatus).isEqualTo(LetterLastStatus.CONTACT_SHARED_BY_OTHER)
+        }
+
+        @Test
+        fun `둘 다 연락처를 공유한 경우`() {
+            val myLetter =
+                Letter(bottle = PING_PONG_BOTTLE, user = TARGET_USER, letters = MY_LETTERS, isShareContact = true)
+            val otherLetter =
+                Letter(bottle = PING_PONG_BOTTLE, user = SOURCE_USER, letters = OTHER_LETTERS, isShareContact = true)
+
+            val lastStatus = myLetter.findLastStatusWithOtherLetter(otherLetter)
+
+            assertThat(lastStatus).isEqualTo(LetterLastStatus.CONTACT_SHARED_BY_OTHER)
+        }
+
+        @Test
+        fun `대화가 중단된 경우`() {
+            val stoppedBottle = Bottle(
+                targetUser = TARGET_USER, sourceUser = SOURCE_USER, likeMessage = LikeMessage("hi"),
+                bottleStatus = BottleStatus.SENT, pingPongStatus = PingPongStatus.STOPPED
+            );
+            val myLetter =
+                Letter(bottle = stoppedBottle, user = TARGET_USER, letters = MY_LETTERS, isShareContact = true)
+            val otherLetter =
+                Letter(bottle = stoppedBottle, user = SOURCE_USER, letters = OTHER_LETTERS, isShareContact = true)
+
+            val lastStatus = myLetter.findLastStatusWithOtherLetter(otherLetter)
+
+            assertThat(lastStatus).isEqualTo(LetterLastStatus.CONVERSATION_STOPPED)
+        }
+    }
+}

--- a/app/src/test/kotlin/com/nexters/bottles/app/bottle/domain/LetterTest.kt
+++ b/app/src/test/kotlin/com/nexters/bottles/app/bottle/domain/LetterTest.kt
@@ -18,16 +18,8 @@ class LetterTest {
             targetUser = TARGET_USER, sourceUser = SOURCE_USER, likeMessage = LikeMessage("hi"),
             bottleStatus = BottleStatus.SENT, pingPongStatus = PingPongStatus.ACTIVE
         );
-        private val MY_LETTERS = listOf(
-            LetterQuestionAndAnswer(question = "question1"),
-            LetterQuestionAndAnswer(question = "question2"),
-            LetterQuestionAndAnswer(question = "question3")
-        )
-        private val OTHER_LETTERS = listOf(
-            LetterQuestionAndAnswer(question = "question1"),
-            LetterQuestionAndAnswer(question = "question2"),
-            LetterQuestionAndAnswer(question = "question3")
-        )
+        private val MY_LETTERS = listOf(LetterQuestionAndAnswer(question = "question1"))
+        private val OTHER_LETTERS = listOf(LetterQuestionAndAnswer(question = "question1"))
     }
 
     @Nested
@@ -45,8 +37,20 @@ class LetterTest {
 
         @Test
         fun `내가 문답을 작성했을 경우`() {
-            val myLetter = Letter(bottle = PING_PONG_BOTTLE, user = TARGET_USER, letters = MY_LETTERS)
-            val otherLetter = Letter(bottle = PING_PONG_BOTTLE, user = SOURCE_USER, letters = OTHER_LETTERS)
+            val myLetter = Letter(
+                bottle = PING_PONG_BOTTLE, user = TARGET_USER, letters = listOf(
+                    LetterQuestionAndAnswer(question = "question1"),
+                    LetterQuestionAndAnswer(question = "question2"),
+                    LetterQuestionAndAnswer(question = "question3")
+                )
+            )
+            val otherLetter = Letter(
+                bottle = PING_PONG_BOTTLE, user = SOURCE_USER, letters = listOf(
+                    LetterQuestionAndAnswer(question = "question1"),
+                    LetterQuestionAndAnswer(question = "question2"),
+                    LetterQuestionAndAnswer(question = "question3")
+                )
+            )
             myLetter.registerAnswer(1, "답변")
 
             val lastStatus = myLetter.findLastStatusWithOtherLetter(otherLetter)
@@ -56,8 +60,20 @@ class LetterTest {
 
         @Test
         fun `상대방이 문답을 작성했을 경우`() {
-            val myLetter = Letter(bottle = PING_PONG_BOTTLE, user = TARGET_USER, letters = MY_LETTERS)
-            val otherLetter = Letter(bottle = PING_PONG_BOTTLE, user = SOURCE_USER, letters = OTHER_LETTERS)
+            val myLetter = Letter(
+                bottle = PING_PONG_BOTTLE, user = TARGET_USER, letters = listOf(
+                    LetterQuestionAndAnswer(question = "question1"),
+                    LetterQuestionAndAnswer(question = "question2"),
+                    LetterQuestionAndAnswer(question = "question3")
+                )
+            )
+            val otherLetter = Letter(
+                bottle = PING_PONG_BOTTLE, user = SOURCE_USER, letters = listOf(
+                    LetterQuestionAndAnswer(question = "question1"),
+                    LetterQuestionAndAnswer(question = "question2"),
+                    LetterQuestionAndAnswer(question = "question3")
+                )
+            )
             otherLetter.registerAnswer(1, "답변")
 
             val lastStatus = myLetter.findLastStatusWithOtherLetter(otherLetter)


### PR DESCRIPTION
## 💡 이슈 번호
close: #468 

## ✨ 작업 내용
- 문답 목록 조회 api v2를 구현했습니다.

## 🚀 전달 사항
- lastStatus 응답값 추가
- active, done -> pingpong 으로 합치기
- 전송시간 기준으로 정렬