### PR TITLE
[Fix/518] 핑퐁 목록 조회 v2 API를 수정한다

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/admin/facade/AdminFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/admin/facade/AdminFacade.kt
@@ -130,6 +130,9 @@ class AdminFacade(
             CacheEvict(PING_PONG_BOTTLE_LIST, key = "1"),
             CacheEvict(PING_PONG_BOTTLE_LIST, key = "2"),
             CacheEvict(PING_PONG_BOTTLE_LIST, key = "9"),
+            CacheEvict(PING_PONG_BOTTLE_LIST, key = "1 + '-v2'"),
+            CacheEvict(PING_PONG_BOTTLE_LIST, key = "2 + '-v2'"),
+            CacheEvict(PING_PONG_BOTTLE_LIST, key = "9 + '-v2'"),
         ]
     )
     fun forceCleanUp() {

--- a/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleCachingService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/bottle/service/BottleCachingService.kt
@@ -31,7 +31,9 @@ class BottleCachingService(
     @Caching(
         evict = [
             CacheEvict(PING_PONG_BOTTLE_LIST, key = "#sourceUserId"),
-            CacheEvict(PING_PONG_BOTTLE_LIST, key = "#targetUserId")
+            CacheEvict(PING_PONG_BOTTLE_LIST, key = "#targetUserId"),
+            CacheEvict(PING_PONG_BOTTLE_LIST, key = "#sourceUserId + '-v2'"),
+            CacheEvict(PING_PONG_BOTTLE_LIST, key = "#targetUserId + '-v2'"),
         ]
     )
     fun evictPingPongList(sourceUserId: Long, targetUserId: Long) {


### PR DESCRIPTION
## 💡 이슈 번호
close: #518 

## ✨ 작업 내용
- 문답 시작 시 핑퐁 목록 조회 v2 api에서 제대로 조회되지 않는 문제 -> 핑퐁 목록 v2에 대한 캐시를 evict 하는 부분이 누락됨

## 🚀 전달 사항
