### PR TITLE
[Feature/521] 자기소개 작성하고 받는 첫 보틀 3개로 수정

### DIFF
--- a/api/src/main/kotlin/com/nexters/bottles/api/user/facade/UserProfileFacade.kt
+++ b/api/src/main/kotlin/com/nexters/bottles/api/user/facade/UserProfileFacade.kt
@@ -73,7 +73,7 @@ class UserProfileFacade(
     fun upsertIntroduction(userId: Long, registerIntroductionRequest: RegisterIntroductionRequest) {
         validateIntroduction(registerIntroductionRequest)
 
-        profileService.saveIntroduction(userId, registerIntroductionRequest.introduction)
+        profileService.saveIntroduction(userId, registerIntroductionRequest.introduction, FIRST_MATCHING_COUNT)
     }
 
     fun getMyProfile(userId: Long): UserProfileResponse {
@@ -191,5 +191,6 @@ class UserProfileFacade(
 
     companion object {
         private const val FILE_NAME_DELIMITER = "_"
+        private const val FIRST_MATCHING_COUNT = 3
     }
 }

--- a/app/src/main/kotlin/com/nexters/bottles/app/user/service/UserProfileService.kt
+++ b/app/src/main/kotlin/com/nexters/bottles/app/user/service/UserProfileService.kt
@@ -40,15 +40,17 @@ class UserProfileService(
     }
 
     @Transactional
-    fun saveIntroduction(userId: Long, introduction: List<QuestionAndAnswer>) {
+    fun saveIntroduction(userId: Long, introduction: List<QuestionAndAnswer>, firstMatchingCount: Int) {
         val user = userRepository.findByIdOrNull(userId) ?: throw IllegalStateException("회원가입 상태를 문의해주세요")
         profileRepository.findByUserId(user.id)?.let {
             val isFirstRegisterIntroduction = it.introduction.isEmpty()
             it.introduction = introduction
             if (isFirstRegisterIntroduction) {
-                applicationEventPublisher.publishEvent(
-                    IntroductionSaveEventDto(userId = userId)
-                )
+                repeat(firstMatchingCount) {
+                    applicationEventPublisher.publishEvent(
+                        IntroductionSaveEventDto(userId = userId)
+                    )
+                }
             }
         } ?: run {
             profileRepository.save(


### PR DESCRIPTION
## 💡 이슈 번호
close: #521 

## ✨ 작업 내용
자기소개 작성하고 받는 첫 보틀 3개로 수정

## 🚀 전달 사항
요거 2가지 중 고민하다 일단 코드 변경이 적고 쉬운 방향으로 골랐습니다 🙇 추후 변경이 필요할 것 같긴하네요

1. 매칭에서 리스트로 반환
2. 어플리케이션 이벤트를 N번 반환